### PR TITLE
Feature/dont autocreate topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Fixed
+- Do not auto-create topics when using `describe`, `consume` or `produce`
+
+## 0.0.1 - 2018-12-12
+### Added
+- Initial version
+
+[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/0.0.1...HEAD

--- a/operations/common-operation.go
+++ b/operations/common-operation.go
@@ -163,3 +163,24 @@ func kafkaVersion(s string) sarama.KafkaVersion {
 
 	return v
 }
+
+func topicExists(client *sarama.Client, name string) (bool, error) {
+
+	var (
+		err    error
+		topics []string
+	)
+
+	if topics, err = (*client).Topics(); err != nil {
+		output.Failf("failed to read topics err=%v", err)
+		return false, err
+	}
+
+	for _, topic := range topics {
+		if topic == name {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/operations/consumer-operation.go
+++ b/operations/consumer-operation.go
@@ -78,6 +78,7 @@ func (operation *ConsumerOperation) Consume(topic string, flags ConsumerFlags) {
 func (operation *ConsumerOperation) init(topic string, args ConsumerFlags) {
 
 	var err error
+	var topExists bool
 
 	clientContext := createClientContext()
 
@@ -92,6 +93,14 @@ func (operation *ConsumerOperation) init(topic string, args ConsumerFlags) {
 
 	if operation.client, err = createClient(&clientContext); err != nil {
 		output.Failf("failed to create client: %v", err)
+	}
+
+	if topExists, err = topicExists(&operation.client, operation.topic); err != nil {
+		output.Failf("failed to read topics err=%v", err)
+	}
+
+	if !topExists {
+		output.Failf("topic '%s' does not exist", topic)
 	}
 
 	if operation.offsetManager, err = createOffsetManager(operation.client, operation.args.ConsumerGroup); err != nil {

--- a/operations/producer-operation.go
+++ b/operations/producer-operation.go
@@ -25,6 +25,24 @@ func (operation *ProducerOperation) Produce(topic string, flags ProducerFlags) {
 
 	clientContext := createClientContext()
 
+	var (
+		err       error
+		client    sarama.Client
+		topExists bool
+	)
+
+	if client, err = createClient(&clientContext); err != nil {
+		output.Failf("failed to create client err=%v", err)
+	}
+
+	if topExists, err = topicExists(&client, topic); err != nil {
+		output.Failf("failed to read topics err=%v", err)
+	}
+
+	if !topExists {
+		output.Failf("topic '%s' does not exist", topic)
+	}
+
 	config := createClientConfig(&clientContext)
 	config.Producer.RequiredAcks = sarama.WaitForAll
 	config.Producer.Return.Successes = true

--- a/operations/topic-operation.go
+++ b/operations/topic-operation.go
@@ -105,14 +105,23 @@ func (operation *TopicOperation) DescribeTopic(topic string) {
 		client sarama.Client
 		admin  sarama.ClusterAdmin
 		err    error
+		exists bool
 	)
-
-	if admin, err = createClusterAdmin(&context); err != nil {
-		output.Failf("failed to create cluster admin: %v", err)
-	}
 
 	if client, err = createClient(&context); err != nil {
 		output.Failf("failed to create client err=%v", err)
+	}
+
+	if exists, err = topicExists(&client, topic); err != nil {
+		output.Failf("failed to read topics err=%v", err)
+	}
+
+	if !exists {
+		output.Failf("topic '%s' does not exist", topic)
+	}
+
+	if admin, err = createClusterAdmin(&context); err != nil {
+		output.Failf("failed to create cluster admin: %v", err)
 	}
 
 	var t, _ = readTopic(&client, &admin, topic, true, false, true, true)


### PR DESCRIPTION
When using `kafkactl describe`, `kafkactl consume` and `kafkactl produce` topics are auto-created if they don't exist. 

This seems counter intuitive. An error message that the topic doesn't exist should be shown instead. Maybe a flag could be added in the future to opt-in for auto-creation.