### PR TITLE
9: Add config file /etc/kafkactl/config.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ sudo mv kafkactl /usr/local/bin/kafkactl
 
 ### create a config file
 
-create `~/.kafkactl.yml` with a definition of contexts that should be available 
+create `~/.kafkactl/config.yml` with a definition of contexts that should be available
 
 ```yaml
 contexts:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,7 +48,7 @@ func init() {
 	rootCmd.AddCommand(produce.CmdProduce)
 
 	// use upper-case letters for shorthand params to avoid conflicts with local flags
-	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config-file", "C", "", "config file (default is $HOME/.kafkactl.yml)")
+	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config-file", "C", "", "config file (defaults are $HOME/.kafkactl/config.yml, /etc/kafkactl/config.yml)")
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "V", false, "verbose output")
 }
 
@@ -65,9 +65,10 @@ func initConfig() {
 			os.Exit(1)
 		}
 
-		// Search config in home directory with name ".kafkactl.yml"
-		viper.AddConfigPath(home)
-		viper.SetConfigName(".kafkactl")
+		// Search config in home directory with name "./kafkactl/config.yml" and in /etc/kafkactl/config.yml
+		viper.AddConfigPath("/etc/kafkactl")
+		viper.AddConfigPath(home + "/.kafkactl")
+		viper.SetConfigName("config")
 	}
 
 	viper.AutomaticEnv() // read in environment variables that match


### PR DESCRIPTION
Warning: Also changes user specific config to ~/.kafkactl/config.yml
The advantage is that it's more in line with kubectl, where it's ~/.kube/config

Also, it's more in line with how viper operates.