### PR TITLE
Some minor improvements for the help of the consume cmd

### DIFF
--- a/cmd/consume/consume.go
+++ b/cmd/consume/consume.go
@@ -8,18 +8,18 @@ import (
 var flags operations.ConsumerFlags
 
 var CmdConsume = &cobra.Command{
-	Use:   "consume",
+	Use:   "consume TOPIC",
 	Short: "consume messages from a topic",
-	Args:  cobra.MinimumNArgs(1),
+	Args:  cobra.ExactArgs(1),
 	Run: func(cobraCmd *cobra.Command, args []string) {
 		(&operations.ConsumerOperation{}).Consume(args[0], flags)
 	},
 }
 
 func init() {
-	CmdConsume.Flags().BoolVarP(&flags.PrintKeys, "print-keys", "k", false, "print message printKeys")
-	CmdConsume.Flags().BoolVarP(&flags.PrintTimestamps, "print-timestamps", "t", false, "print message printTimestamps")
-	CmdConsume.Flags().IntSliceP("partitions", "p", flags.Partitions, "partitions to consume")
+	CmdConsume.Flags().BoolVarP(&flags.PrintKeys, "print-keys", "k", false, "print message keys")
+	CmdConsume.Flags().BoolVarP(&flags.PrintTimestamps, "print-timestamps", "t", false, "print message timestamps")
+	CmdConsume.Flags().IntSliceP("partitions", "p", flags.Partitions, "partitions to consume. The default is to consume from all partitions.")
 	CmdConsume.Flags().BoolVarP(&flags.FromBeginning, "from-beginning", "b", false, "set offset for consumer to the oldest offset")
 	CmdConsume.Flags().StringVarP(&flags.OutputFormat, "output", "o", flags.OutputFormat, "Output format. One of: json|yaml")
 }


### PR DESCRIPTION
* Mention the positional argument in the usage string
* Only one topic is expected, enforce that only one is given
* Mention the default for the partition option
* Correct accidental? terms printKeys, printTimestamps (but maybe I did not understand what you meant here exactly)