### PR TITLE
#6: Add support for Avro serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add Avro schema support in `produce` and `consume` commands
+
 ## 1.0.0 - 2019-01-23
 ### Added
 - Add `alter topic` command for increasing partition count and editing topic configs

--- a/README.md
+++ b/README.md
@@ -148,6 +148,23 @@ kafkactl produce my-topic --key=my-key --value=my-value --partitioner=random
 kafkactl produce my-topic --key=my-key --value=my-value --partitioner=random
 ```
 
+### Avro support
+
+The `produce` and `consume` commands support Avro serialization by supplying a schema with the `--schema` flag.
+
+```bash
+echo '{
+    "type": "record",
+    "name": "LongList",
+    "fields" : [
+       {"name": "next", "type": ["null", "LongList"], "default": null}
+    ]
+}' >> ./path/to/avro-schema.json
+
+kafkactl consume --schema ./path/to/avro-schema.json
+kafkactl produce --schema ./path/to/avro-schema.json --value '{"next":{"LongList":{}}}'
+```
+
 ### Altering topics
 
 Using the `alter topic` command allows you to change the partition count and topic-level configurations of an existing topic.

--- a/cmd/consume/consume.go
+++ b/cmd/consume/consume.go
@@ -22,4 +22,5 @@ func init() {
 	CmdConsume.Flags().IntSliceP("partitions", "p", flags.Partitions, "partitions to consume. The default is to consume from all partitions.")
 	CmdConsume.Flags().BoolVarP(&flags.FromBeginning, "from-beginning", "b", false, "set offset for consumer to the oldest offset")
 	CmdConsume.Flags().StringVarP(&flags.OutputFormat, "output", "o", flags.OutputFormat, "Output format. One of: json|yaml")
+	CmdConsume.Flags().StringVarP(&flags.SchemaPath, "schema", "a", flags.SchemaPath, "path to avro schema file to use for deserialization of the value")
 }

--- a/cmd/produce/produce.go
+++ b/cmd/produce/produce.go
@@ -23,5 +23,6 @@ func init() {
 	CmdProduce.Flags().StringVarP(&flags.Key, "key", "k", "", "key to use for all messages")
 	CmdProduce.Flags().StringVarP(&flags.Value, "value", "v", "", "value to produce")
 	CmdProduce.Flags().StringVarP(&flags.Separator, "separator", "S", "", "separator to split key and value from stdin")
+	CmdProduce.Flags().StringVarP(&flags.SchemaPath, "schema", "a", "", "path to avro schema file to use for serialization of the value")
 	CmdProduce.Flags().BoolVarP(&flags.Silent, "silent", "s", false, "do not write to standard output")
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db
 	github.com/hashicorp/hcl v1.0.0
 	github.com/inconshreveable/mousetrap v1.0.0
+	github.com/linkedin/goavro v2.2.0
 	github.com/magiconair/properties v1.8.0
 	github.com/mitchellh/go-homedir v1.0.0
 	github.com/mitchellh/mapstructure v1.1.2


### PR DESCRIPTION
Adds basic Avro serialization support. 

No idea if this is helpful yet as it's my first experience with Avro.

Should probably add schema registry support as well in the future.