### PR TITLE
Add default config generation if no config found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add rate limiting for multiple messages with `--rate` flag
+- A default config file is now generated when no config was found
 
 ## 1.3.0 - 2019-11-13
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,12 @@ $ go get -u github.com/deviceinsight/kafkactl
 
 ## Configuration
 
+If no config file is found, a default config is generated in `$HOME/.config/kafkactl/config.yml`.
+This configuration is suitable to get started with a single node cluster on a local machine. 
+
 ### Create a config file
 
-Create `~/.kafkactl/config.yml` with a definition of contexts that should be available
+Create `$HOME/.config/kafkactl/config.yml` with a definition of contexts that should be available
 
 ```yaml
 contexts:


### PR DESCRIPTION
For issue #22 
I am not quite sure about implementation. I've tried to found a way to ask viper if there is config file, but found none. So it's a glob checking here for a file. Maybe should move some constants like 'yml' and 'config' to variables.