### PR TITLE
Allow omitting the CA cert

### DIFF
--- a/operations/common-operation.go
+++ b/operations/common-operation.go
@@ -3,7 +3,6 @@ package operations
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
 	"github.com/Shopify/sarama"
 	"github.com/deviceinsight/kafkactl/output"
 	"github.com/spf13/viper"

--- a/operations/common-operation.go
+++ b/operations/common-operation.go
@@ -130,20 +130,18 @@ func setupCerts(insecure bool, certPath, caPath, keyPath string) (*tls.Config, e
 		return nil, nil
 	}
 
-	if certPath == "" || caPath == "" || keyPath == "" {
-		err := fmt.Errorf("certificate, CA and key path are required - got cert=%#v ca=%#v key=%#v", certPath, caPath, keyPath)
-		return nil, err
-	}
+	var caPool *x509.CertPool = nil
+	if caPath != "" {
+		caString, err := ioutil.ReadFile(caPath)
+		if err != nil {
+			return nil, err
+		}
 
-	caString, err := ioutil.ReadFile(caPath)
-	if err != nil {
-		return nil, err
-	}
-
-	caPool := x509.NewCertPool()
-	ok := caPool.AppendCertsFromPEM(caString)
-	if !ok {
-		output.Failf("unable to add ca at %s to certificate pool", caPath)
+		caPool := x509.NewCertPool()
+		ok := caPool.AppendCertsFromPEM(caString)
+		if !ok {
+			output.Failf("unable to add ca at %s to certificate pool", caPath)
+		}
 	}
 
 	clientCert, err := tls.LoadX509KeyPair(certPath, keyPath)


### PR DESCRIPTION
If a private CA is not being used, a CA certificate is not required. This is the case, for instance, when TLS client cert authentication is enabled in Amazon's managed Kafka.