### PR TITLE
allow enabling tls without specifying additional options (#Fixes 44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - show oldestOffset,lead values when describing consumer groups
 - allow omitting the CA cert 
 - show error message when trying to reset offset of a non-empty group
+- allow enabling tls without specifying additional options
 
 ## 1.7.0 - 2020-03-05
 

--- a/README.md
+++ b/README.md
@@ -73,11 +73,13 @@ contexts:
     - remote-cluster003:9092
 
     # optional: tls config
-    tlsCA: my-ca
-    tlsCert: my-cert
-    tlsCertKey: my-key
-    # set tlsInsecure to true to ignore all tls verification (defaults to false)
-    tlsInsecure: false
+    tls:
+      enabled: true
+      ca: my-ca
+      cert: my-cert
+      certKey: my-key
+      # set insecure to true to ignore all tls verification (defaults to false)
+      insecure: false
 
     # optional: sasl support
     sasl:


### PR DESCRIPTION
# Description

Allow enabling tls without specifying additional options.
This PR changes the names of tls parameters in the config.

Fixes #44 