### PR TITLE
WIP: Initial dirty patch for connecting to TLS using default config

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/deviceinsight/kafkactl/cmd/alter"
 	"github.com/deviceinsight/kafkactl/cmd/config"
 	"github.com/deviceinsight/kafkactl/cmd/consume"
@@ -15,9 +19,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 var cfgFile string
@@ -128,13 +129,24 @@ func generateDefaultConfig() error {
 contexts:
   localhost:
     brokers:
-    - localhost:9092
-current-context: localhost`
+    - localhost:9092`
 
 	if os.Getenv("BROKER") != "" {
 		// this is useful for running in docker
 		defaultConfigContent = strings.Replace(defaultConfigContent, "localhost:9092", os.Getenv("BROKER"), -1)
 	}
+
+	if os.Getenv("TLS") == "true" {
+		defaultConfigContent = defaultConfigContent + `
+    tls:
+      enabled: true`
+		if os.Getenv("TLS_ALLOW_INSECURE") == "true" {
+			defaultConfigContent = defaultConfigContent + `
+      insecure: true`
+		}
+	}
+
+	defaultConfigContent = defaultConfigContent + "\ncurrent-context: localhost"
 
 	_, err = f.WriteString(defaultConfigContent)
 


### PR DESCRIPTION
# Description

This change is the initial naive fix for #55. I feel there are better ways to solve it, but I'm using this as a stepping stone to start a discussion on what the best way to fix it is.

Personally, I believe the best way to solve it is to add command-line switches that override the config. But given the sparse usage of switches in kafkactl, I'm not sure that's what the project owners want.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [ ] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.md` was updated
- [ ] a usage example was added to `README.md`
