### PR TITLE
improve and document overriding config keys via env vars (closes #55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- improved and documented overriding config keys via environment variables
+
 ## 1.9.0 - 2020-06-19
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:latest
 ENV USER docker
-ENV BROKER localhost:9092
+ENV BROKERS localhost:9092
 COPY kafkactl /
 ENTRYPOINT ["/kafkactl"]

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Create `$HOME/.config/kafkactl/config.yml` with a definition of contexts that sh
 
 ```yaml
 contexts:
-  localhost:
+  default:
     brokers:
     - localhost:9092
   remote-cluster:
@@ -109,7 +109,7 @@ contexts:
     defaultPartitioner: "hash"
 
 
-current-context: localhost
+current-context: default
 ```
 
 The config file location is resolved by
@@ -166,7 +166,7 @@ kafkactl completion fish > ~/.config/fish/completions/kafkactl.fish
 Assuming your Kafka broker is accessible as `kafka:9092`, you can list topics by running: 
 
 ```bash
-docker run --env BROKER=kafka:9092 deviceinsight/kafkactl:latest get topics
+docker run --env BROKERS=kafka:9092 deviceinsight/kafkactl:latest get topics
 ```
 
 If a more elaborate config is needed, you can mount it as a volume:
@@ -174,6 +174,21 @@ If a more elaborate config is needed, you can mount it as a volume:
 ```bash
 docker run -v /absolute/path/to/config.yml:/etc/kafkactl/config.yml deviceinsight/kafkactl get topics
 ``` 
+
+## Configuration via environment variables
+
+Every key in the `config.yml` can be overwritten via environment variables. The corresponding environment variable
+for a key can be found by applying the following rules:
+
+1. replace `.` by `_`
+1. replace `-` by `_`
+1. write the key name in ALL CAPS
+
+e.g. the key `contexts.default.tls.certKey` has the corresponding environment variable `CONTEXTS_DEFAULT_TLS_CERTKEY`.
+
+If environment variables for the `default` context should be set, the prefix `CONTEXTS_DEFAULT_` can be omitted.
+So, instead of `CONTEXTS_DEFAULT_TLS_CERTKEY` one can also set `TLS_CERTKEY`.
+See **root_test.go** for more examples.
 
 ## Command documentation
 

--- a/cmd/config/view_test.go
+++ b/cmd/config/view_test.go
@@ -1,0 +1,52 @@
+package config_test
+
+import (
+	"github.com/deviceinsight/kafkactl/test_util"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+)
+
+func TestViewConfigWithEnvVariablesInGeneratedConfigSet(t *testing.T) {
+
+	test_util.StartUnitTest(t)
+
+	currentDir, err := os.Getwd()
+
+	if err != nil {
+		t.Fatalf("unable to read current working dir: %v", err)
+	}
+
+	newConfigFile := path.Join(currentDir, "non-existing-config.yml")
+
+	if err := os.Setenv("KAFKA_CTL_CONFIG", newConfigFile); err != nil {
+		t.Fatalf("unable to set env variable: %v", err)
+	}
+
+	if err := os.Setenv("BROKERS", "env-broker:9092"); err != nil {
+		t.Fatalf("unable to set env variable: %v", err)
+	}
+
+	kafkaCtl := test_util.CreateKafkaCtlCommand()
+
+	defaultConfigContent := `
+contexts:
+  default:
+    brokers: env-broker:9092
+current-context: default`
+
+	if _, err := kafkaCtl.Execute("config", "view"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	configContent, err := ioutil.ReadFile(newConfigFile)
+	if err != nil {
+		t.Fatalf("error reading generated config %s %v", newConfigFile, err)
+	}
+
+	test_util.AssertEquals(t, defaultConfigContent, string(configContent))
+	test_util.AssertEquals(t, defaultConfigContent, kafkaCtl.GetStdOut())
+
+	_ = os.Remove(newConfigFile)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,22 @@ import (
 var cfgFile string
 var Verbose bool
 
+var envMapping = map[string]string{
+	"BROKERS":             "CONTEXTS_DEFAULT_BROKERS",
+	"TLS_ENABLED":         "CONTEXTS_DEFAULT_TLS_ENABLED",
+	"TLS_CA":              "CONTEXTS_DEFAULT_TLS_CA",
+	"TLS_CERT":            "CONTEXTS_DEFAULT_TLS_CERT",
+	"TLS_CERTKEY":         "CONTEXTS_DEFAULT_TLS_CERTKEY",
+	"TLS_INSECURE":        "CONTEXTS_DEFAULT_TLS_INSECURE",
+	"SASL_ENABLED":        "CONTEXTS_DEFAULT_SASL_ENABLED",
+	"SASL_USERNAME":       "CONTEXTS_DEFAULT_SASL_USERNAME",
+	"SASL_PASSWORD":       "CONTEXTS_DEFAULT_SASL_PASSWORD",
+	"CLIENTID":            "CONTEXTS_DEFAULT_CLIENTID",
+	"KAFKAVERSION":        "CONTEXTS_DEFAULT_KAFKAVERSION",
+	"AVRO_SCHEMAREGISTRY": "CONTEXTS_DEFAULT_AVRO_SCHEMAREGISTRY",
+	"DEFAULTPARTITIONER":  "CONTEXTS_DEFAULT_DEFAULTPARTITIONER",
+}
+
 var configPaths = []string{"$HOME/.config/kafkactl", "$HOME/.kafkactl", "$SNAP_DATA/kafkactl", "/etc/kafkactl"}
 
 func NewKafkactlCommand(streams output.IOStreams) *cobra.Command {
@@ -77,11 +93,27 @@ func initConfig() {
 		output.IoStreams.EnableDebug()
 	}
 
+	mapEnvVariables()
+
+	replacer := strings.NewReplacer("-", "_", ".", "_")
+	viper.SetEnvKeyReplacer(replacer)
+
+	viper.SetDefault("contexts.default.brokers", []string{"localhost:9092"})
+	viper.SetDefault("current-context", "default")
+
 	viper.SetConfigType("yml")
 	viper.AutomaticEnv() // read in environment variables that match
 
 	if err := readConfig(); err != nil {
 		output.Fail(err)
+	}
+}
+
+func mapEnvVariables() {
+	for short, long := range envMapping {
+		if os.Getenv(short) != "" && os.Getenv(long) == "" {
+			_ = os.Setenv(long, os.Getenv(short))
+		}
 	}
 }
 
@@ -92,7 +124,10 @@ func readConfig() error {
 		return nil
 	}
 
-	if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+	_, isConfigFileNotFoundError := err.(viper.ConfigFileNotFoundError)
+	_, isOsPathError := err.(*os.PathError)
+
+	if !isConfigFileNotFoundError && !isOsPathError {
 		return errors.Errorf("Error reading config file: %s (%v)", viper.ConfigFileUsed(), err)
 	} else {
 		err = generateDefaultConfig()
@@ -112,35 +147,20 @@ func readConfig() error {
 
 // generateDefaultConfig generates default config in case there is no config
 func generateDefaultConfig() error {
-	if err := os.MkdirAll(os.ExpandEnv(configPaths[0]), os.FileMode(0700)); err != nil {
+	cfgFile := filepath.Join(os.ExpandEnv(configPaths[0]), "config.yml")
+
+	if os.Getenv("KAFKA_CTL_CONFIG") != "" {
+		cfgFile = os.Getenv("KAFKA_CTL_CONFIG")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(cfgFile), os.FileMode(0700)); err != nil {
 		return err
 	}
-	pathToConfig := filepath.Join(os.ExpandEnv(configPaths[0]), "config.yml")
-	f, err := os.Create(pathToConfig)
-	if err != nil {
-		return fmt.Errorf("failed to generate default config at %s", pathToConfig)
-	}
-	defer func(f *os.File) {
-		_ = f.Close()
-	}(f)
 
-	defaultConfigContent := `
-contexts:
-  localhost:
-    brokers:
-    - localhost:9092
-current-context: localhost`
-
-	if os.Getenv("BROKER") != "" {
-		// this is useful for running in docker
-		defaultConfigContent = strings.Replace(defaultConfigContent, "localhost:9092", os.Getenv("BROKER"), -1)
+	if err := viper.WriteConfigAs(cfgFile); err != nil {
+		return err
 	}
 
-	_, err = f.WriteString(defaultConfigContent)
-
-	if err == nil {
-		output.Debugf("generated default config at %s", pathToConfig)
-	}
-
-	return err
+	output.Debugf("generated default config at %s", cfgFile)
+	return nil
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,80 @@
+package cmd_test
+
+import (
+	"github.com/deviceinsight/kafkactl/test_util"
+	"github.com/spf13/viper"
+	"os"
+	"testing"
+)
+
+func TestEnvironmentVariableLoading(t *testing.T) {
+
+	test_util.StartUnitTest(t)
+
+	_ = os.Setenv("CONTEXTS_DEFAULT_BROKERS", "broker1:9092 broker2:9092")
+	_ = os.Setenv("CONTEXTS_DEFAULT_TLS_ENABLED", "true")
+	_ = os.Setenv("CONTEXTS_DEFAULT_TLS_CERT", "my-cert")
+	_ = os.Setenv("CONTEXTS_DEFAULT_TLS_CERTKEY", "my-cert-key")
+	_ = os.Setenv("CURRENT_CONTEXT", "non-existing-context")
+
+	kafkaCtl := test_util.CreateKafkaCtlCommand()
+
+	if _, err := kafkaCtl.Execute("version"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	if len(viper.GetStringSlice("contexts.default.brokers")) != 2 {
+		t.Fatalf("expected two default brokers but got: %s", viper.GetString("contexts.default.brokers"))
+	}
+
+	test_util.AssertEquals(t, "broker1:9092", viper.GetStringSlice("contexts.default.brokers")[0])
+	test_util.AssertEquals(t, "broker2:9092", viper.GetStringSlice("contexts.default.brokers")[1])
+	test_util.AssertEquals(t, "true", viper.GetString("contexts.default.tls.enabled"))
+	test_util.AssertEquals(t, "my-cert", viper.GetString("contexts.default.tls.cert"))
+	test_util.AssertEquals(t, "my-cert-key", viper.GetString("contexts.default.tls.certKey"))
+	test_util.AssertEquals(t, "non-existing-context", viper.GetString("current-context"))
+}
+
+func TestEnvironmentVariableLoadingAliases(t *testing.T) {
+
+	test_util.StartUnitTest(t)
+
+	_ = os.Setenv("BROKERS", "broker1:9092 broker2:9092")
+	_ = os.Setenv("TLS_ENABLED", "true")
+	_ = os.Setenv("TLS_CA", "my-ca")
+	_ = os.Setenv("TLS_CERT", "my-cert")
+	_ = os.Setenv("TLS_CERTKEY", "my-cert-key")
+	_ = os.Setenv("TLS_INSECURE", "true")
+	_ = os.Setenv("SASL_ENABLED", "true")
+	_ = os.Setenv("SASL_USERNAME", "user")
+	_ = os.Setenv("SASL_PASSWORD", "pass")
+	_ = os.Setenv("CLIENTID", "my-client")
+	_ = os.Setenv("KAFKAVERSION", "2.0.1")
+	_ = os.Setenv("AVRO_SCHEMAREGISTRY", "registry:8888")
+	_ = os.Setenv("DEFAULTPARTITIONER", "hash")
+
+	kafkaCtl := test_util.CreateKafkaCtlCommand()
+
+	if _, err := kafkaCtl.Execute("version"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	if len(viper.GetStringSlice("contexts.default.brokers")) != 2 {
+		t.Fatalf("expected two default brokers but got: %s", viper.GetString("contexts.default.brokers"))
+	}
+
+	test_util.AssertEquals(t, "broker1:9092", viper.GetStringSlice("contexts.default.brokers")[0])
+	test_util.AssertEquals(t, "broker2:9092", viper.GetStringSlice("contexts.default.brokers")[1])
+	test_util.AssertEquals(t, "true", viper.GetString("contexts.default.tls.enabled"))
+	test_util.AssertEquals(t, "my-ca", viper.GetString("contexts.default.tls.ca"))
+	test_util.AssertEquals(t, "my-cert", viper.GetString("contexts.default.tls.cert"))
+	test_util.AssertEquals(t, "my-cert-key", viper.GetString("contexts.default.tls.certKey"))
+	test_util.AssertEquals(t, "true", viper.GetString("contexts.default.tls.insecure"))
+	test_util.AssertEquals(t, "true", viper.GetString("contexts.default.sasl.enabled"))
+	test_util.AssertEquals(t, "user", viper.GetString("contexts.default.sasl.username"))
+	test_util.AssertEquals(t, "pass", viper.GetString("contexts.default.sasl.password"))
+	test_util.AssertEquals(t, "my-client", viper.GetString("contexts.default.clientID"))
+	test_util.AssertEquals(t, "2.0.1", viper.GetString("contexts.default.kafkaVersion"))
+	test_util.AssertEquals(t, "registry:8888", viper.GetString("contexts.default.avro.schemaRegistry"))
+	test_util.AssertEquals(t, "hash", viper.GetString("contexts.default.defaultPartitioner"))
+}

--- a/it-config.yml
+++ b/it-config.yml
@@ -1,9 +1,9 @@
 contexts:
-  localhost:
+  default:
     brokers:
       - localhost:19092
       - localhost:29092
       - localhost:39092
     avro:
       schemaRegistry: localhost:18081
-current-context: localhost
+current-context: default

--- a/operations/common-operation.go
+++ b/operations/common-operation.go
@@ -47,6 +47,10 @@ func CreateClientContext() (ClientContext, error) {
 
 	context.Name = viper.GetString("current-context")
 
+	if viper.Get("contexts."+context.Name) == nil {
+		return context, errors.Errorf("no context with name %s found", context.Name)
+	}
+
 	if viper.GetString("contexts."+context.Name+".tlsCA") != "" ||
 		viper.GetString("contexts."+context.Name+".tlsCert") != "" ||
 		viper.GetString("contexts."+context.Name+".tlsCertKey") != "" ||


### PR DESCRIPTION
# Description

Improve handling of environment variables

Fixes #55

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [x] a usage example was added to `README.md`
