### PR TITLE
Support starting off with the entire system root CA pool instead of o…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- TLS configuration now starts off with the System's CA pool instead of a completely empty one. This improves support for AWS MSK with PCAs.
+
 ## 1.11.1 - 2020-08-11
 
 ## 1.11.0 - 2020-08-07


### PR DESCRIPTION
…nly the passed in CA

# Description

This change allows starting with the system CA pool and adding in the additional CA. AWS MSK with client auth using a private CA in ACM seems to require this to operate correctly (both the AWS trusted CAs and the private CA need to be in the pool).

I'll update this PR with docs provided it looks good otherwise.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.md` was updated
- [ ] a usage example was added to `README.md`
