### PR TITLE
Install CA certificates

### DIFF
--- a/Dockerfile.Ubuntu
+++ b/Dockerfile.Ubuntu
@@ -17,6 +17,11 @@ RUN useradd -r -g kafkactl -d /home/kafkactl -s /sbin/nologin -c "Docker image u
 RUN echo "source /etc/bash_completion" > /home/kafkactl/.bashrc
 RUN echo "source /etc/bash_completion.d/kafkactl " >> /home/kafkactl/.bashrc
 
+# Install CA certificates
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+&& rm -rf /var/lib/apt/lists/*
+
 WORKDIR /home/kafkactl
 RUN chown -R kafkactl:kafkactl /home/kafkactl
 


### PR DESCRIPTION
# Description

Adds the CA certificates normally included in Ubuntu inside the container.

Fixes # 63

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Documentation

- [ ] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.md` was updated
- [ ] a usage example was added to `README.md`
