### PR TITLE
Add certificates to TlsConfig when tls.insecure = true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Add certificates to TlsConfig when tls.insecure = true
+
 ## 1.13.2 - 2020-11-05
 
 ### Fixed

--- a/operations/common-operation.go
+++ b/operations/common-operation.go
@@ -193,10 +193,6 @@ func setupTlsConfig(tlsConfig TlsConfig) (*tls.Config, error) {
 		return nil, errors.Errorf("tls should be enabled at this point")
 	}
 
-	if tlsConfig.Insecure {
-		return &tls.Config{InsecureSkipVerify: true}, nil
-	}
-
 	caPool, err := x509.SystemCertPool()
 	if err != nil {
 		output.Warnf("error reading system cert pool: %v", err)
@@ -228,6 +224,11 @@ func setupTlsConfig(tlsConfig TlsConfig) (*tls.Config, error) {
 		RootCAs:      caPool,
 		Certificates: []tls.Certificate{clientCert},
 	}
+
+	if tlsConfig.Insecure {
+		bundle.InsecureSkipVerify = true
+	}
+
 	return bundle, nil
 }
 


### PR DESCRIPTION
# Description

The insecure flag was returning an empty tlsConfig (no certificates included). I believe insecure should still include the certificates, we just don't want to verify them. I think the current implementation doesn't make much sense... Not sure what was the use case for a TlsConfig with no certificates. Previous PR is #39 but feels like it was not tested.

This is necessary for connecting to Heroku Kafka since it provides certificates with a different hostname.
https://devcenter.heroku.com/articles/kafka-on-heroku#using-kafka-in-go-applications

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`