### PR TITLE
Better value for misleading retention example

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ kafkactl alter topic my-topic --replication-factor 2
 
 The topic configs can be edited by supplying key value pairs as follows:
 ```bash
-kafkactl alter topic my-topic --config retention.ms=3600 --config cleanup.policy=compact
+kafkactl alter topic my-topic --config retention.ms=3600000 --config cleanup.policy=compact
 ```
 
 > :bulb: use the flag `--validate-only` to perform a dry-run without actually modifying the topic 


### PR DESCRIPTION
# Description

3600 is often used to present the hour when the unit is seconds, for the millisecond unit it will be better to set this as 3600000.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Documentation

I think the changelog update is not relevant in this case.