### PR TITLE
fix consumer error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - SASL mechanism support now also implemented for cluster admin
+- process no longer gets stuck when deserialization error occurs 
 
 ## 1.16.0 - 2021-02-25
 

--- a/cmd/config/useContext_test.go
+++ b/cmd/config/useContext_test.go
@@ -19,11 +19,13 @@ func TestUseContextAutoCompletionIntegration(t *testing.T) {
 
 	outputLines := strings.Split(strings.TrimSpace(kafkaCtl.GetStdOut()), "\n")
 
-	if len(outputLines) != 4 {
-		t.Fatalf("unexpected output. expected two lines got %d: %s", len(outputLines), kafkaCtl.GetStdOut())
+	expectedContexts := []string{"default", "no-avro", "sasl-admin", "sasl-user"}
+
+	if len(outputLines) != len(expectedContexts)+1 {
+		t.Fatalf("unexpected output. expected %d lines got %d: %s", len(expectedContexts)+1, len(outputLines), kafkaCtl.GetStdOut())
 	}
 
-	test_util.AssertEquals(t, "default", outputLines[0])
-	test_util.AssertEquals(t, "sasl-admin", outputLines[1])
-	test_util.AssertEquals(t, "sasl-user", outputLines[2])
+	for _, context := range expectedContexts {
+		test_util.AssertContains(t, context, outputLines)
+	}
 }

--- a/it-config.yml
+++ b/it-config.yml
@@ -10,6 +10,15 @@ contexts:
       schemaRegistry: localhost:18081
     kafkaversion: 2.6.0
 
+  # context without avro
+  no-avro:
+    brokers:
+      - localhost:19093
+      - localhost:29093
+      - localhost:39093
+    requestTimeout: 15s
+    kafkaversion: 2.6.0
+
   # sasl context as admin
   sasl-admin:
     brokers:


### PR DESCRIPTION
# Description

Fixes error handling in consumer.
A deserialization error led to kafkactl being blocked waiting for internal channels to be read from.

Fixes #77 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
