### PR TITLE
add command get brokers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add new command `get brokers` to get the list of brokers advertised by Kafka
+
 ## 1.17.0 - 2021-04-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -522,3 +522,12 @@ kafkactl delete acl --cluster --operation any --pattern any
 # delete all consumer-group acls with operation describe, patternType prefixed and permissionType allow
 kafkactl delete acl --groups --operation describe --pattern prefixed --allow
 ```
+
+### Getting Brokers
+
+To get the list of brokers of a kafka cluster use `get brokers`
+
+```bash
+# get the list of brokers
+kafkactl get brokers
+```

--- a/cmd/get/get-brokers.go
+++ b/cmd/get/get-brokers.go
@@ -1,0 +1,29 @@
+package get
+
+import (
+	"github.com/deviceinsight/kafkactl/operations"
+	"github.com/deviceinsight/kafkactl/operations/k8s"
+	"github.com/deviceinsight/kafkactl/output"
+	"github.com/spf13/cobra"
+)
+
+func newGetBrokersCmd() *cobra.Command {
+
+	var flags operations.GetBrokersFlags
+
+	var cmdGetBrokers = &cobra.Command{
+		Use:   "brokers",
+		Short: "list brokers",
+		Run: func(cmd *cobra.Command, args []string) {
+			if !(&k8s.K8sOperation{}).TryRun(cmd, args) {
+				if err := (&operations.BrokerOperation{}).GetBrokers(flags); err != nil {
+					output.Fail(err)
+				}
+			}
+		},
+	}
+
+	cmdGetBrokers.Flags().StringVarP(&flags.OutputFormat, "output", "o", flags.OutputFormat, "output format. One of: json|yaml|compact")
+
+	return cmdGetBrokers
+}

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -9,12 +9,13 @@ func NewGetCmd() *cobra.Command {
 	var cmdGet = &cobra.Command{
 		Use:     "get",
 		Aliases: []string{"list"},
-		Short:   "get info about topics, consumerGroups, acls",
+		Short:   "get info about topics, consumerGroups, acls, brokers",
 	}
 
 	cmdGet.AddCommand(newGetTopicsCmd())
 	cmdGet.AddCommand(newGetConsumerGroupsCmd())
 	cmdGet.AddCommand(newGetAclCmd())
+	cmdGet.AddCommand(newGetBrokersCmd())
 
 	return cmdGet
 }

--- a/operations/broker-operation.go
+++ b/operations/broker-operation.go
@@ -1,0 +1,85 @@
+package operations
+
+import (
+	"github.com/Shopify/sarama"
+	"github.com/deviceinsight/kafkactl/output"
+	"github.com/pkg/errors"
+	"sort"
+	"strconv"
+)
+
+type Broker struct {
+	Id      int32
+	Address string
+}
+
+type GetBrokersFlags struct {
+	OutputFormat string
+}
+
+type BrokerOperation struct {
+}
+
+func (operation *BrokerOperation) GetBrokers(flags GetBrokersFlags) error {
+
+	var (
+		err     error
+		context ClientContext
+		client  sarama.Client
+		brokers []*sarama.Broker
+	)
+
+	if context, err = CreateClientContext(); err != nil {
+		return err
+	}
+
+	if client, err = CreateClient(&context); err != nil {
+		return errors.Wrap(err, "failed to create client")
+	}
+
+	brokers = client.Brokers()
+
+	tableWriter := output.CreateTableWriter()
+
+	if flags.OutputFormat == "" {
+		if err := tableWriter.WriteHeader("ID", "ADDRESS"); err != nil {
+			return err
+		}
+	} else if flags.OutputFormat == "compact" {
+		tableWriter.Initialize()
+	} else if flags.OutputFormat != "json" && flags.OutputFormat != "yaml" {
+		return errors.Errorf("unknown outputFormat: %s", flags.OutputFormat)
+	}
+
+	brokerList := make([]Broker, 0, len(brokers))
+	for _, broker := range brokers {
+		brokerList = append(brokerList, Broker{Id: broker.ID(), Address: broker.Addr()})
+	}
+
+	sort.Slice(brokerList, func(i, j int) bool {
+		return brokerList[i].Id < brokerList[j].Id
+	})
+
+	if flags.OutputFormat == "json" || flags.OutputFormat == "yaml" {
+		return output.PrintObject(brokerList, flags.OutputFormat)
+	} else if flags.OutputFormat == "compact" {
+		for _, t := range brokerList {
+			if err := tableWriter.Write(t.Address); err != nil {
+				return err
+			}
+		}
+	} else {
+		for _, t := range brokerList {
+			if err := tableWriter.Write(strconv.Itoa(int(t.Id)), t.Address); err != nil {
+				return err
+			}
+		}
+	}
+
+	if flags.OutputFormat == "compact" || flags.OutputFormat == "" {
+		if err := tableWriter.Flush(); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
# Description

Get the list of brokers advertised by kafka cluster. It's useful to
troubleshooting connection problems.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [x] a usage example was added to `README.md`
