### PR TITLE
Remove --generator flag, as its been deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 1.17.0 - 2021-04-06
 
 ### Fixed
+- Compatibility with new versions of `kubectl` by removing deprecated parameter from the command
+
+### Fixed
 - SASL mechanism support now also implemented for cluster admin
 - process no longer gets stuck when deserialization error occurs 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## 1.17.0 - 2021-04-06
-
 ### Fixed
 - Compatibility with new versions of `kubectl` by removing deprecated parameter from the command
+
+## 1.17.0 - 2021-04-06
 
 ### Fixed
 - SASL mechanism support now also implemented for cluster admin

--- a/operations/k8s/executor.go
+++ b/operations/k8s/executor.go
@@ -2,12 +2,13 @@ package k8s
 
 import (
 	"fmt"
-	"github.com/deviceinsight/kafkactl/operations"
-	"github.com/deviceinsight/kafkactl/output"
 	"math/rand"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/deviceinsight/kafkactl/operations"
+	"github.com/deviceinsight/kafkactl/output"
 )
 
 type Version struct {
@@ -37,7 +38,6 @@ func randomString(n int) string {
 }
 
 func getKubectlVersion(kubectlBinary string, runner Runner) Version {
-
 	bytes, err := runner.ExecuteAndReturn(kubectlBinary, []string{"version", "--client", "--short"})
 	if err != nil {
 		output.Fail(err)
@@ -97,7 +97,6 @@ func (kubectl *executor) SetKubectlBinary(bin string) {
 }
 
 func (kubectl *executor) Run(dockerImageType string, kafkactlArgs []string, podEnvironment []string) error {
-
 	if KafkaCtlVersion == "" {
 		KafkaCtlVersion = "latest"
 	}
@@ -105,8 +104,10 @@ func (kubectl *executor) Run(dockerImageType string, kafkactlArgs []string, podE
 
 	podName := "kafkactl-" + randomString(10)
 
-	kubectlArgs := []string{"run", "--generator=run-pod/v1", "--rm", "-i", "--tty", "--restart=Never", podName,
-		"--image", dockerImage}
+	kubectlArgs := []string{
+		"run", "--rm", "-i", "--tty", "--restart=Never", podName,
+		"--image", dockerImage,
+	}
 
 	if kubectl.kubeConfig != "" {
 		kubectlArgs = append(kubectlArgs, "--kubeconfig", kubectl.kubeConfig)
@@ -130,7 +131,6 @@ func (kubectl *executor) Run(dockerImageType string, kafkactlArgs []string, podE
 }
 
 func (kubectl *executor) exec(args []string) error {
-
 	cmd := fmt.Sprintf("exec: %s %s", kubectl.kubectlBinary, join(args))
 	output.Debugf("kubectl version: %d.%d.%d", kubectl.version.Major, kubectl.version.Minor, kubectl.version.Patch)
 	output.Debugf(cmd)


### PR DESCRIPTION
# Description

`kubectl` has deprecated the use of the `--generator` flag. It is not needed, anyway.
This aims to remove it and fix the compatibility with newer versions of the tool.

Fixes #82 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Documentation

- [X] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`