### PR TITLE
replace cmd with entrypoint to preserve kubectl call when providing cmd in docker run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Replace `CMD` with `ENTRYPOINT` in Ubuntu Dockerfile to restore behavior documented in readme
+
 ## 1.17.0 - 2021-04-06
 
 ### Fixed

--- a/Dockerfile.Ubuntu
+++ b/Dockerfile.Ubuntu
@@ -26,4 +26,4 @@ WORKDIR /home/kafkactl
 RUN chown -R kafkactl:kafkactl /home/kafkactl
 
 USER kafkactl
-CMD ["kafkactl"]
+ENTRYPOINT ["kafkactl"]


### PR DESCRIPTION
# Description

The example command from the Readme does not work with the Ubuntu image:
```
docker run --env BROKERS=kafka:9092 deviceinsight/kafkactl:latest get topics
```
`kafkactl` is set as `CMD` and will be overwriten with `get topics`. `kafkactl` needs to be set as `ENTRYPOINT` instead to execute `kafkactl get topics`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`