### PR TITLE
Feature/docker entrypoint

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run golangci-lint
-        uses: actions-contrib/golangci-lint@v1
+        uses: golangci/golangci-lint-action@v2
 
   test:
     name: Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Compatibility with new versions of `kubectl` by removing deprecated parameter from the command
+- Replace `CMD` with `ENTRYPOINT` in Ubuntu Dockerfile to restore behavior documented in readme
 
 ## 1.17.0 - 2021-04-06
 

--- a/Dockerfile.Scratch
+++ b/Dockerfile.Scratch
@@ -1,4 +1,4 @@
-  
+
 FROM alpine:latest as certs
 RUN apk --update --no-cache add ca-certificates && update-ca-certificates
 

--- a/Dockerfile.Ubuntu
+++ b/Dockerfile.Ubuntu
@@ -26,4 +26,4 @@ WORKDIR /home/kafkactl
 RUN chown -R kafkactl:kafkactl /home/kafkactl
 
 USER kafkactl
-CMD ["kafkactl"]
+ENTRYPOINT ["kafkactl"]

--- a/operations/k8s/executor.go
+++ b/operations/k8s/executor.go
@@ -96,7 +96,7 @@ func (kubectl *executor) SetKubectlBinary(bin string) {
 	kubectl.kubectlBinary = bin
 }
 
-func (kubectl *executor) Run(dockerImageType string, kafkactlArgs []string, podEnvironment []string) error {
+func (kubectl *executor) Run(dockerImageType, entryPoint string, kafkactlArgs []string, podEnvironment []string) error {
 	if KafkaCtlVersion == "" {
 		KafkaCtlVersion = "latest"
 	}
@@ -124,7 +124,7 @@ func (kubectl *executor) Run(dockerImageType string, kafkactlArgs []string, podE
 		kubectlArgs = append(kubectlArgs, kubectl.extra...)
 	}
 
-	kubectlArgs = append(kubectlArgs, "--")
+	kubectlArgs = append(kubectlArgs, "--command", "--", entryPoint)
 	kubectlArgs = append(kubectlArgs, kafkactlArgs...)
 
 	return kubectl.exec(kubectlArgs)

--- a/operations/k8s/k8s-operation.go
+++ b/operations/k8s/k8s-operation.go
@@ -51,7 +51,7 @@ func (operation *K8sOperation) Attach() error {
 
 	podEnvironment := parsePodEnvironment(operation.context)
 
-	return exec.Run("ubuntu", []string{"bash"}, podEnvironment)
+	return exec.Run("ubuntu", "bash", nil, podEnvironment)
 }
 
 func (operation *K8sOperation) TryRun(cmd *cobra.Command, args []string) bool {
@@ -91,7 +91,7 @@ func (operation *K8sOperation) Run(cmd *cobra.Command, args []string) error {
 	kafkaCtlCommand = append(kafkaCtlCommand, args...)
 	kafkaCtlCommand = append(kafkaCtlCommand, kafkaCtlFlags...)
 
-	return exec.Run("scratch", kafkaCtlCommand, podEnvironment)
+	return exec.Run("scratch", "/kafkactl", kafkaCtlCommand, podEnvironment)
 }
 
 func parseFlags(cmd *cobra.Command) ([]string, error) {


### PR DESCRIPTION
# Description

This is a rebased and extended version of PR #84 

---

The example command from the Readme does not work with the Ubuntu image:
```
docker run --env BROKERS=kafka:9092 deviceinsight/kafkactl:latest get topics
```
`kafkactl` is set as `CMD` and will be overwriten with `get topics`. `kafkactl` needs to be set as `ENTRYPOINT` instead to execute `kafkactl get topics`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
