### PR TITLE
make required-acks configurable (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- the default for required-acks in the producer has been changed to WaitForLocal in order to align with the JVM Producer.
+  In addition, this setting is now also configurable.
+
 ## 1.17.2 - 2021-06-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ contexts:
     # optional: changes the default partitioner
     defaultPartitioner: "hash"
 
+    # optional: changes default required acks in produce request
+    # see: https://pkg.go.dev/github.com/Shopify/sarama?utm_source=godoc#RequiredAcks
+    requiredAcks: "WaitForAll"
+
 
 current-context: default
 ```
@@ -363,6 +367,11 @@ kafkactl produce my-topic --key=my-key --value=my-value --header key1:value1 --h
 The following example writes the key from base64 and value from hex:
 ```bash
 kafkactl produce my-topic --key=dGVzdC1rZXk= --key-encoding=base64 --value=0000000000000000 --value-encoding=hex
+```
+
+You can control how many replica acknowledgements are needed for a response:
+```bash
+kafkactl produce my-topic --key=my-key --value=my-value --required-acks=WaitForAll
 ```
 
 ### Avro support

--- a/cmd/produce/produce.go
+++ b/cmd/produce/produce.go
@@ -28,6 +28,7 @@ func NewProduceCmd() *cobra.Command {
 
 	cmdProduce.Flags().Int32VarP(&flags.Partition, "partition", "p", -1, "partition to produce to")
 	cmdProduce.Flags().StringVarP(&flags.Partitioner, "partitioner", "P", "", "the partitioning scheme to use. Can be `murmur2`, `hash`, `hash-ref` `manual`, or `random`. (default is murmur2)")
+	cmdProduce.Flags().StringVarP(&flags.RequiredAcks, "required-acks", "", "", "required acks. One of `NoResponse`, `WaitForLocal`, `WaitForAll`. (default is WaitForLocal)")
 	cmdProduce.Flags().StringVarP(&flags.Key, "key", "k", "", "key to use for all messages")
 	cmdProduce.Flags().StringVarP(&flags.Value, "value", "v", "", "value to produce")
 	cmdProduce.Flags().StringVarP(&flags.File, "file", "f", "", "file to read input from")

--- a/operations/common-operation.go
+++ b/operations/common-operation.go
@@ -53,6 +53,7 @@ type ClientContext struct {
 	KafkaVersion       sarama.KafkaVersion
 	AvroSchemaRegistry string
 	DefaultPartitioner string
+	RequiredAcks       string
 }
 
 func CreateClientContext() (ClientContext, error) {
@@ -88,6 +89,7 @@ func CreateClientContext() (ClientContext, error) {
 	}
 	context.AvroSchemaRegistry = viper.GetString("contexts." + context.Name + ".avro.schemaRegistry")
 	context.DefaultPartitioner = viper.GetString("contexts." + context.Name + ".defaultPartitioner")
+	context.RequiredAcks = viper.GetString("contexts." + context.Name + ".requiredAcks")
 	context.Sasl.Enabled = viper.GetBool("contexts." + context.Name + ".sasl.enabled")
 	context.Sasl.Username = viper.GetString("contexts." + context.Name + ".sasl.username")
 	context.Sasl.Password = viper.GetString("contexts." + context.Name + ".sasl.password")


### PR DESCRIPTION
# Description

change default of required-acks and make it configurable

Fixes #90

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Documentation
- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [x] the configuration yaml was changed and the example config in `README.md` was updated
- [x] a usage example was added to `README.md`
