### PR TITLE
fix repeated calls to schema registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Calls to the AVRO schema registry are now cached correctly
+
 ## 1.18.1 - 2021-07-15
 
 ### Fixed

--- a/operations/consumer/CachingSchemaRegistry.go
+++ b/operations/consumer/CachingSchemaRegistry.go
@@ -1,7 +1,7 @@
 package consumer
 
 import (
-	"github.com/landoop/schema-registry"
+	schemaregistry "github.com/landoop/schema-registry"
 	"github.com/pkg/errors"
 )
 
@@ -27,7 +27,7 @@ func CreateCachingSchemaRegistry(avroSchemaRegistry string) (*CachingSchemaRegis
 	return registry, nil
 }
 
-func (registry CachingSchemaRegistry) Subjects() ([]string, error) {
+func (registry *CachingSchemaRegistry) Subjects() ([]string, error) {
 	var err error = nil
 
 	if len(registry.subjects) == 0 {
@@ -37,7 +37,7 @@ func (registry CachingSchemaRegistry) Subjects() ([]string, error) {
 	return registry.subjects, err
 }
 
-func (registry CachingSchemaRegistry) GetSchemaByID(id int) (string, error) {
+func (registry *CachingSchemaRegistry) GetSchemaByID(id int) (string, error) {
 	var err error = nil
 
 	if _, ok := registry.schemas[id]; !ok {


### PR DESCRIPTION
# Description

Fixes schema-registry responses being persisted into a copy of `CachingSchemaRegistry` by simply declaring the method receiver as a pointer. This should dramatically improve AVRO deserialization speed as we no longer look up `/subjects` for every message.

Note: After this change the CPU utilization of `kafkactl` is a lot higher

Fixes #93 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
