### PR TITLE
[#89] Implement delete consumer-group command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added new commands `delete consumer-group` to delete a consumer-group
+
 ## 1.18.1 - 2021-07-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -489,6 +489,15 @@ kafkactl reset offset my-group --topic my-topic --newest
 kafkactl reset offset my-group --topic my-topic --partition 5 --offset 100
 ```
 
+### Delete consumer groups
+
+In order to delete a consumer group or a list of consumer groups use `delete consumer-group`
+
+```bash
+# delete consumer group my-group
+kafkactl delete consumer-group my-group
+```
+
 ### ACL Management
 
 Available ACL operations are documented [here](https://docs.confluent.io/platform/current/kafka/authorization.html#operations).

--- a/cmd/deletion/delete-consumer-group.go
+++ b/cmd/deletion/delete-consumer-group.go
@@ -1,0 +1,25 @@
+package deletion
+
+import (
+        "github.com/deviceinsight/kafkactl/operations/consumergroups"
+        "github.com/deviceinsight/kafkactl/output"
+        "github.com/spf13/cobra"
+)
+
+func newDeleteConsumerGroupCmd() *cobra.Command {
+
+        var cmdDeleteConsumerGroup = &cobra.Command{
+				Use:   "consumer-group CONSUMER-GROUP",
+				Aliases: []string{"consumer-groups"},
+                Short: "delete a consumer-group",
+                Args:  cobra.MinimumNArgs(1),
+                Run: func(cmd *cobra.Command, args []string) {
+                        if err := (&consumergroups.ConsumerGroupOperation{}).DeleteConsumerGroups(args); err != nil {
+                                output.Fail(err)
+                        }
+                },
+                ValidArgsFunction: consumergroups.CompleteConsumerGroups,
+		}
+		
+        return cmdDeleteConsumerGroup
+}

--- a/cmd/deletion/delete-consumer-group_test.go
+++ b/cmd/deletion/delete-consumer-group_test.go
@@ -1,0 +1,109 @@
+package deletion_test
+
+import (
+	"errors"
+	"fmt"
+	"github.com/Rican7/retry"
+	"github.com/Rican7/retry/backoff"
+	"github.com/Rican7/retry/strategy"
+	"github.com/deviceinsight/kafkactl/test_util"
+	"github.com/deviceinsight/kafkactl/util"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDeleteSingleConsumerGroupIntegration(t *testing.T) {
+
+	test_util.StartIntegrationTest(t)
+	topicName := test_util.CreateTopic(t, "delete-consumer-group-single")
+	groupName := test_util.CreateConsumerGroup(t, topicName, "consumer-group-to-be-deleted")
+
+	kafkaCtl := test_util.CreateKafkaCtlCommand()
+
+	if _, err := kafkaCtl.Execute("delete", "consumer-group", groupName); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	test_util.AssertEquals(t, fmt.Sprintf("consumer-group deleted: %s", groupName), kafkaCtl.GetStdOut())
+
+	verifyConsumerGroupDeleted(t, kafkaCtl, groupName)
+}
+
+func TestDeleteMultipleConsumerGroupsIntegration(t *testing.T) {
+
+	test_util.StartIntegrationTest(t)
+	topicName := test_util.CreateTopic(t, "delete-consumer-group-multiple")
+	groupName1 := test_util.CreateConsumerGroup(t, topicName, "consumer-group-to-be-deleted")
+	groupName2 := test_util.CreateConsumerGroup(t, topicName, "consumer-group-to-be-deleted")
+
+	kafkaCtl := test_util.CreateKafkaCtlCommand()
+
+	if _, err := kafkaCtl.Execute("delete", "consumer-group", groupName1, groupName2); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	outputLines := strings.Split(strings.TrimSpace(kafkaCtl.GetStdOut()), "\n")
+
+	if len(outputLines) != 2 {
+		t.Fatalf("unexpected output. expected two lines got %d: %s", len(outputLines), kafkaCtl.GetStdOut())
+	}
+
+	test_util.AssertEquals(t, fmt.Sprintf("consumer-group deleted: %s", groupName1), outputLines[0])
+	test_util.AssertEquals(t, fmt.Sprintf("consumer-group deleted: %s", groupName2), outputLines[1])
+
+	verifyConsumerGroupDeleted(t, kafkaCtl, groupName1)
+	verifyConsumerGroupDeleted(t, kafkaCtl, groupName2)
+}
+
+func TestDeleteConsumerGroupAutoCompletionIntegration(t *testing.T) {
+
+	test_util.StartIntegrationTest(t)
+	topicName := test_util.CreateTopic(t, "delete-consumer-group-completion")
+	prefix := "delete-complete-"
+
+	groupName1 := test_util.CreateConsumerGroup(t, topicName, prefix+"a")
+	groupName2 := test_util.CreateConsumerGroup(t, topicName, prefix+"b")
+	groupName3 := test_util.CreateConsumerGroup(t, topicName, prefix+"c")
+
+	kafkaCtl := test_util.CreateKafkaCtlCommand()
+	kafkaCtl.Verbose = false
+
+	if _, err := kafkaCtl.Execute("__complete", "delete", "consumer-group", ""); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	outputLines := strings.Split(strings.TrimSpace(kafkaCtl.GetStdOut()), "\n")
+
+	test_util.AssertContains(t, groupName1, outputLines)
+	test_util.AssertContains(t, groupName2, outputLines)
+	test_util.AssertContains(t, groupName3, outputLines)
+}
+
+func verifyConsumerGroupDeleted(t *testing.T, kafkaCtl test_util.KafkaCtlTestCommand, groupName string) {
+
+	checkConsumerGrouDeleted := func(attempt uint) error {
+		_, err := kafkaCtl.Execute("get", "consumer-groups", "-o", "compact")
+
+		if err != nil {
+			return err
+		} else {
+			consumerGroups := strings.SplitN(kafkaCtl.GetStdOut(), "\n", -1)
+			if util.ContainsString(consumerGroups, groupName) {
+				return errors.New("consumer-group not yet deleted")
+			} else {
+				return nil
+			}
+		}
+	}
+
+	err := retry.Retry(
+		checkConsumerGrouDeleted,
+		strategy.Limit(5),
+		strategy.Backoff(backoff.Linear(10*time.Millisecond)),
+	)
+
+	if err != nil {
+		t.Fatalf("consumer-group %s was not deleted: %v", groupName, err)
+	}
+}

--- a/cmd/deletion/delete.go
+++ b/cmd/deletion/delete.go
@@ -12,6 +12,7 @@ func NewDeleteCmd() *cobra.Command {
 	}
 
 	cmdDelete.AddCommand(newDeleteTopicCmd())
+	cmdDelete.AddCommand(newDeleteConsumerGroupCmd())
 	cmdDelete.AddCommand(newDeleteAclCmd())
 	return cmdDelete
 }

--- a/operations/consumergroups/consumer-group-operation.go
+++ b/operations/consumergroups/consumer-group-operation.go
@@ -535,3 +535,29 @@ func CompleteConsumerGroupsFiltered(flags DescribeConsumerGroupFlags) ([]string,
 func CompleteConsumerGroups(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	return CompleteConsumerGroupsFiltered(DescribeConsumerGroupFlags{FilterTopic: ""})
 }
+
+func (operation *ConsumerGroupOperation) DeleteConsumerGroups(consumerGroups []string) error {
+
+	var (
+			err     error
+			context operations.ClientContext
+			admin   sarama.ClusterAdmin
+	)
+
+	if context, err = operations.CreateClientContext(); err != nil {
+			return err
+	}
+
+	if admin, err = operations.CreateClusterAdmin(&context); err != nil {
+			return errors.Wrap(err, "failed to create cluster admin")
+	}
+
+	for _, consumerGroup := range consumerGroups {
+			if err = admin.DeleteConsumerGroup(consumerGroup); err != nil {
+					return errors.Wrap(err, "failed to delete consumerGroup")
+			} else {
+					output.Infof("consumer-group deleted: %s", consumerGroup)
+			}
+	}
+	return nil
+}


### PR DESCRIPTION
# Description

Implement `delete consumer-group` command
As it is possible to delete multiple groups at the same time, an alias `delete consumer-groups` is also defined.

Fixes #89 Delete a consumer group

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [x] a usage example was added to `README.md`
