### PR TITLE
[#96] Filter -C and --config-file option in kubernetes context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Filter -C and --config-file option in kubernetes context
+
 ## 1.19.0 - 2021-07-26
 
 ### Added
@@ -13,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Calls to the AVRO schema registry are now cached correctly
-
 
 ## 1.18.1 - 2021-07-15
 


### PR DESCRIPTION
# Description

Filter `-C` and `--config-file` options in kubernetes context
Forwarding `-C` or `--config-file` options to kafkactl executed in a pod produce errors. The content of this option is a path on the local path system and is not relevant for the execution in the pod.

Fixes [#96]

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.md` was updated
- [ ] a usage example was added to `README.md`
