### PR TITLE
[#98] Allow execution of delete command with k8s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support `delete` command when accessing a remote cluster deployed on kubernetes
+
 ## 1.19.0 - 2021-07-26
 
 ### Added

--- a/cmd/deletion/delete-acl.go
+++ b/cmd/deletion/delete-acl.go
@@ -2,6 +2,7 @@ package deletion
 
 import (
 	"github.com/deviceinsight/kafkactl/operations/acl"
+	"github.com/deviceinsight/kafkactl/operations/k8s"
 	"github.com/deviceinsight/kafkactl/output"
 	"github.com/spf13/cobra"
 )
@@ -16,8 +17,10 @@ func newDeleteAclCmd() *cobra.Command {
 		Short:   "delete an acl",
 		Args:    cobra.MaximumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := (&acl.AclOperation{}).DeleteAcl(flags); err != nil {
-				output.Fail(err)
+			if !(&k8s.K8sOperation{}).TryRun(cmd, args) {
+				if err := (&acl.AclOperation{}).DeleteAcl(flags); err != nil {
+					output.Fail(err)
+				}
 			}
 		},
 	}

--- a/cmd/deletion/delete-consumer-group.go
+++ b/cmd/deletion/delete-consumer-group.go
@@ -1,25 +1,28 @@
 package deletion
 
 import (
-        "github.com/deviceinsight/kafkactl/operations/consumergroups"
-        "github.com/deviceinsight/kafkactl/output"
-        "github.com/spf13/cobra"
+	"github.com/deviceinsight/kafkactl/operations/consumergroups"
+	"github.com/deviceinsight/kafkactl/operations/k8s"
+	"github.com/deviceinsight/kafkactl/output"
+	"github.com/spf13/cobra"
 )
 
 func newDeleteConsumerGroupCmd() *cobra.Command {
 
-        var cmdDeleteConsumerGroup = &cobra.Command{
-				Use:   "consumer-group CONSUMER-GROUP",
-				Aliases: []string{"consumer-groups"},
-                Short: "delete a consumer-group",
-                Args:  cobra.MinimumNArgs(1),
-                Run: func(cmd *cobra.Command, args []string) {
-                        if err := (&consumergroups.ConsumerGroupOperation{}).DeleteConsumerGroups(args); err != nil {
-                                output.Fail(err)
-                        }
-                },
-                ValidArgsFunction: consumergroups.CompleteConsumerGroups,
-		}
-		
-        return cmdDeleteConsumerGroup
+	var cmdDeleteConsumerGroup = &cobra.Command{
+		Use:     "consumer-group CONSUMER-GROUP",
+		Aliases: []string{"consumer-groups"},
+		Short:   "delete a consumer-group",
+		Args:    cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if !(&k8s.K8sOperation{}).TryRun(cmd, args) {
+				if err := (&consumergroups.ConsumerGroupOperation{}).DeleteConsumerGroups(args); err != nil {
+					output.Fail(err)
+				}
+			}
+		},
+		ValidArgsFunction: consumergroups.CompleteConsumerGroups,
+	}
+
+	return cmdDeleteConsumerGroup
 }

--- a/cmd/deletion/delete-topic.go
+++ b/cmd/deletion/delete-topic.go
@@ -2,6 +2,7 @@ package deletion
 
 import (
 	"github.com/deviceinsight/kafkactl/operations"
+	"github.com/deviceinsight/kafkactl/operations/k8s"
 	"github.com/deviceinsight/kafkactl/output"
 	"github.com/spf13/cobra"
 )
@@ -13,8 +14,10 @@ func newDeleteTopicCmd() *cobra.Command {
 		Short: "delete a topic",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := (&operations.TopicOperation{}).DeleteTopics(args); err != nil {
-				output.Fail(err)
+			if !(&k8s.K8sOperation{}).TryRun(cmd, args) {
+				if err := (&operations.TopicOperation{}).DeleteTopics(args); err != nil {
+					output.Fail(err)
+				}
 			}
 		},
 		ValidArgsFunction: operations.CompleteTopicNames,


### PR DESCRIPTION
# Description

Allow to execute `delete` commands on remote cluster deployed on kubernetes

Note to the reviewer : Usually kafka clusters are deployed with KAFKA_CFG_DELETE_TOPIC_ENABLE=false. So the command `delete topic` won't work on these clusters.

Fixes #98

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.md` was updated
- [ ] a usage example was added to `README.md`
