### PR TITLE
Delete consumer group offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added new command `delete consumer-group-offset` to delete a consumer-group-offset
+
 ## 1.20.0 - 2021-08-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -489,6 +489,17 @@ kafkactl reset offset my-group --topic my-topic --newest
 kafkactl reset offset my-group --topic my-topic --partition 5 --offset 100
 ```
 
+### Delete consumer group offsets
+
+In order to delete a consumer group offset use `delete offset`
+
+```bash
+# delete offset for all partitions of topic my-topic
+kafkactl delete offset my-group --topic my-topic
+# delete offset for partition 1 of topic my-topic
+kafkactl delete offset my-group --topic my-topic --partition 1
+```
+
 ### Delete consumer groups
 
 In order to delete a consumer group or a list of consumer groups use `delete consumer-group`

--- a/cmd/deletion/delete-consumer-group-offset.go
+++ b/cmd/deletion/delete-consumer-group-offset.go
@@ -1,0 +1,34 @@
+package deletion
+
+import (
+	"github.com/deviceinsight/kafkactl/operations/consumergroupoffsets"
+	"github.com/deviceinsight/kafkactl/operations/consumergroups"
+	"github.com/deviceinsight/kafkactl/operations/k8s"
+	"github.com/deviceinsight/kafkactl/output"
+	"github.com/spf13/cobra"
+)
+
+func newDeleteConsumerGroupOffsetCmd() *cobra.Command {
+
+	var offsetFlags consumergroupoffsets.DeleteConsumerGroupOffsetFlags
+
+	var cmdDeleteConsumerGroup = &cobra.Command{
+		Use:     "consumer-group-offset CONSUMER-GROUP --topic=TOPIC --partition=PARTITION",
+		Aliases: []string{"cgo", "offset"},
+		Short:   "delete a consumer-group-offset",
+		Args:    cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if !(&k8s.K8sOperation{}).TryRun(cmd, args) {
+				if err := (&consumergroupoffsets.ConsumerGroupOffsetOperation{}).DeleteConsumerGroupOffset(args[0], offsetFlags); err != nil {
+					output.Fail(err)
+				}
+			}
+		},
+		ValidArgsFunction: consumergroups.CompleteConsumerGroups,
+	}
+
+	cmdDeleteConsumerGroup.Flags().Int32VarP(&offsetFlags.Partition, "partition", "p", -1, "delete offset for this partition. -1 stands for all partitions")
+	cmdDeleteConsumerGroup.Flags().StringVarP(&offsetFlags.Topic, "topic", "t", offsetFlags.Topic, "delete offset for this topic")
+
+	return cmdDeleteConsumerGroup
+}

--- a/cmd/deletion/delete-consumer-group-offset_test.go
+++ b/cmd/deletion/delete-consumer-group-offset_test.go
@@ -1,0 +1,230 @@
+package deletion_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/Rican7/retry"
+	"github.com/Rican7/retry/backoff"
+	"github.com/Rican7/retry/strategy"
+	"github.com/Shopify/sarama"
+	"github.com/deviceinsight/kafkactl/test_util"
+	"github.com/deviceinsight/kafkactl/util"
+	"github.com/pkg/errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDeleteConsumerGroupOffsetIntegration(t *testing.T) {
+	test_util.StartIntegrationTest(t)
+	topicName := test_util.CreateTopic(t, "delete-consumer-group-offset", "--partitions", "3")
+
+	client := test_util.CreateClient(t)
+	defer client.Close()
+	groupName := test_util.GetPrefixedName("cg-delete-offset-test")
+	_, err := sarama.NewConsumerGroupFromClient(groupName, client)
+	if err != nil{
+		t.Fatalf("Fail to create consumer group %s", groupName)
+	}
+
+	// Create offset on the three partitions
+	test_util.MarkOffset(t, client, groupName, topicName, 0,0)
+	test_util.MarkOffset(t, client, groupName, topicName, 1,0)
+	test_util.MarkOffset(t, client, groupName, topicName, 2,0)
+
+	kafkaCtl := test_util.CreateKafkaCtlCommand()
+
+	// Deleting an offset for a topic that does not exist shall fail
+	if _, err := kafkaCtl.Execute("delete", "consumer-group-offset", groupName,
+		"--topic", "this-topic-does-not-exist",
+		"--partition", "0"); err == nil {
+		t.Fatalf("Deleting an offset for a topic that does not exist shall fail")
+	} else {
+		test_util.AssertEquals(t, fmt.Sprintf("no offsets for topic: %s", "this-topic-does-not-exist"), err.Error())
+	}
+
+	// Deleting existing offset of a partition shall succeed
+	// Offsets on other partitions must not be impacted
+	if _, err := kafkaCtl.Execute("delete", "consumer-group-offset", groupName,
+		"--topic", topicName,
+		"--partition", "1"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	test_util.AssertEquals(t, offsetDeletedMessage(groupName, topicName, 1), kafkaCtl.GetStdOut())
+
+	//verify that offset has been deleted for partition 1
+	if err := checkOffsetDeleted(kafkaCtl, groupName, topicName, 1); err != nil {
+		t.Fatal(err.Error())
+	}
+	//verify that offset still exists for partition 0 and 2
+	if err := checkOffsetDeleted(kafkaCtl, groupName, topicName, 0); err == nil {
+		t.Fatalf("offset for partition %d has been deleted", 0)
+	}
+	if err := checkOffsetDeleted(kafkaCtl, groupName, topicName, 2); err == nil {
+		t.Fatalf("offset for partition %d has been deleted", 2)
+	}
+
+	// Deleting an offset that does not exist shall fail
+	if _, err := kafkaCtl.Execute("delete", "consumer-group-offset", groupName,
+		"--topic", topicName,
+		"--partition", "1"); err == nil {
+		t.Fatalf("Deleting an offset that does not exist shall fail")
+	} else {
+		test_util.AssertEquals(t, fmt.Sprintf("No offset for partition: %d", 1), err.Error())
+	}
+
+	// --partition=-1 shall delete all offsets on topic (here partitions 0 and 2)
+	if _, err := kafkaCtl.Execute("delete", "consumer-group-offset", groupName,
+		"--topic", topicName,
+		"--partition", "-1"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+	//verify output messages
+	messages := strings.Split(strings.TrimSpace(kafkaCtl.GetStdOut()), "\n")
+	if !util.ContainsString(messages, offsetDeletedMessage(groupName, topicName, 0)) {
+		t.Fatalf("offset for partition %d not deleted", 0)
+	}
+	if !util.ContainsString(messages, offsetDeletedMessage(groupName, topicName, 2)) {
+		t.Fatalf("offset for partition %d not deleted", 2)
+	}
+	//verify that offsets have been effectively deleted
+	if err := checkOffsetDeleted(kafkaCtl, groupName, topicName, 0); err != nil {
+		t.Fatal(err.Error())
+	}
+	if err := checkOffsetDeleted(kafkaCtl, groupName, topicName, 2); err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
+func TestDeleteConsumerGroupOffsetOnActiveTopicIntegration(t *testing.T) {
+	test_util.StartIntegrationTest(t)
+	topicName := test_util.CreateTopic(t, "delete-consumer-group-offset-active", "--partitions", "1")
+
+	client := test_util.CreateClient(t)
+	defer client.Close()
+	groupName := test_util.GetPrefixedName("cg-delete-offset-test")
+	consumerGroup, err := sarama.NewConsumerGroupFromClient(groupName, client)
+	if err != nil{
+		t.Fatalf("Fail to create consumer group %s", groupName)
+	}
+
+	// Create offset on the three partitions
+	test_util.MarkOffset(t, client, groupName, topicName, 0,0)
+
+	kafkaCtl := test_util.CreateKafkaCtlCommand()
+
+	backgroundCtx := context.Background()
+
+	consumer := consumerGrpHandler{
+		ready: make(chan bool),
+	}
+
+	consumer.ready = make(chan bool)
+	err = consumerGroup.Consume(backgroundCtx, []string{topicName}, &consumer)
+	if err != nil {
+		t.Fatal("fail to create consumer")
+	}
+
+	<-consumer.ready
+
+	// Deleting an offset shall fail is consumer group is active on the topic
+	if _, err := kafkaCtl.Execute("delete", "consumer-group-offset", groupName,
+		"--topic", topicName,
+		"--partition", "0"); err == nil {
+		t.Fatalf("Deleting an offset shall fail is consumer group is active on the topic")
+	} else {
+		if !strings.HasPrefix(err.Error(), failedToDeleteMessage(groupName, topicName, 0)) {
+			t.Fatalf("Unexpected error message: %s", err.Error())
+		}
+	}
+
+	err = consumerGroup.Close()
+	if err != nil {
+		t.Fatal("fail to close consumer group")
+	}
+
+	// consumer group is closed, it shall be possible to delete offset
+	if _, err := kafkaCtl.Execute("delete", "consumer-group-offset", groupName,
+		"--topic", topicName,
+		"--partition", "0"); err != nil {
+		t.Fatalf("Deleting an offset failed")
+	}
+}
+
+func TestDeleteConsumerGroupOffsetAutoCompletionIntegration(t *testing.T) {
+
+	test_util.StartIntegrationTest(t)
+	topicName := test_util.CreateTopic(t, "delete-consumer-group-completion")
+	prefix := "delete-complete-"
+
+	groupName1 := test_util.CreateConsumerGroup(t, topicName, prefix+"a")
+	groupName2 := test_util.CreateConsumerGroup(t, topicName, prefix+"b")
+	groupName3 := test_util.CreateConsumerGroup(t, topicName, prefix+"c")
+
+	kafkaCtl := test_util.CreateKafkaCtlCommand()
+	kafkaCtl.Verbose = false
+
+	if _, err := kafkaCtl.Execute("__complete", "delete", "consumer-group-offset", ""); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	outputLines := strings.Split(strings.TrimSpace(kafkaCtl.GetStdOut()), "\n")
+
+	test_util.AssertContains(t, groupName1, outputLines)
+	test_util.AssertContains(t, groupName2, outputLines)
+	test_util.AssertContains(t, groupName3, outputLines)
+
+}
+
+func offsetDeletedMessage(groupName string, topic string, partition int32) string{
+	return fmt.Sprintf("consumer-group-offset deleted: [group: %s, topic: %s, partition: %d]",
+		groupName, topic, partition)
+}
+func failedToDeleteMessage(groupName string, topic string, partition int32) string{
+	return fmt.Sprintf("failed to delete consumer-group-offset [group: %s, topic: %s, partition: %d]",
+		groupName, topic, partition)
+}
+
+func checkOffsetDeleted( kafkaCtl test_util.KafkaCtlTestCommand, groupName string, topic string, partition int32) error {
+	checkOffsetDeleted := func(attempt uint) error {
+		_, err := kafkaCtl.Execute("describe", "consumer-group", groupName, "-o", "yaml")
+
+		if err != nil {
+			return err
+		} else {
+			consumerGroupDescStr := strings.Split(strings.TrimSpace(kafkaCtl.GetStdOut()), "\n")
+			if util.ContainsString(consumerGroupDescStr, fmt.Sprintf("  - partition: %d", partition)) {
+				return errors.New("consumer-group-offset not exists")
+			} else {
+				return nil
+			}
+		}
+	}
+
+	err := retry.Retry(
+		checkOffsetDeleted,
+		strategy.Limit(5),
+		strategy.Backoff(backoff.Linear(10*time.Millisecond)),
+	)
+
+	if err != nil {
+		return errors.Wrapf(err, "consumer-group-offset [%s, %s, %d] exists: %v", groupName, topic, partition, err)
+	} else {
+		return nil
+	}
+}
+
+type consumerGrpHandler struct{
+	ready chan bool
+}
+
+func (h consumerGrpHandler) Setup(_ sarama.ConsumerGroupSession) error   {
+	// Mark the consumer as ready
+	close(h.ready)
+	return nil
+}
+func (consumerGrpHandler) Cleanup(_ sarama.ConsumerGroupSession) error { return nil }
+func (h consumerGrpHandler) ConsumeClaim(sess sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
+	return nil
+}

--- a/cmd/deletion/delete.go
+++ b/cmd/deletion/delete.go
@@ -8,11 +8,12 @@ func NewDeleteCmd() *cobra.Command {
 
 	var cmdDelete = &cobra.Command{
 		Use:   "delete",
-		Short: "delete topics, consumerGroups, acls",
+		Short: "delete topics, consumerGroups, consumer-group-offset, acls",
 	}
 
 	cmdDelete.AddCommand(newDeleteTopicCmd())
 	cmdDelete.AddCommand(newDeleteConsumerGroupCmd())
+	cmdDelete.AddCommand(newDeleteConsumerGroupOffsetCmd())
 	cmdDelete.AddCommand(newDeleteAclCmd())
 	return cmdDelete
 }


### PR DESCRIPTION
# Description

Kafka 2.4.0 introduced a new api to delete consumer offsets ( [KIP-496: Administrative API to delete consumer offsets](https://cwiki.apache.org/confluence/display/KAFKA/KIP-496%3A+Administrative+API+to+delete+consumer+offsets) )
The API has been implemeted in sarama (Shopify/sarama#2006).

This PR add support for this operation in kafkactl through a new command `delete consumer-group-offset`.
The expected usage is : 
```
Usage:
  kafkactl delete consumer-group-offset CONSUMER-GROUP --topic=TOPIC --partition=PARTITION [flags]

Aliases:
  consumer-group-offset, cgo, offset

Flags:
  -h, --help              help for consumer-group-offset
  -p, --partition int32   delete offset for this partition. -1 stands for all partitions (default -1)
  -t, --topic string      delete offset for this topic
```

`topic` flag is required.

**This MR requires a update of sarama version to work.**

Fixes #88

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ]  ~~the configuration yaml was changed and the example config in `README.md` was updated~~
- [x] a usage example was added to `README.md`
