### PR TITLE
Propagate SASL mechanism into the attached k8s pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- SASL mechanism setting is now supported in `kafkactl attach`
+
 ## 1.20.0 - 2021-08-06
 
 ### Fixed

--- a/operations/k8s/k8s-operation.go
+++ b/operations/k8s/k8s-operation.go
@@ -145,6 +145,7 @@ func parsePodEnvironment(context operations.ClientContext) []string {
 	env = appendBool(env, "SASL_ENABLED", context.Sasl.Enabled)
 	env = appendStringIfDefined(env, "SASL_USERNAME", context.Sasl.Username)
 	env = appendStringIfDefined(env, "SASL_PASSWORD", context.Sasl.Password)
+	env = appendStringIfDefined(env, "SASL_MECHANISM", context.Sasl.Mechanism)
 	env = appendStringIfDefined(env, "CLIENTID", context.ClientID)
 	env = appendStringIfDefined(env, "KAFKAVERSION", context.KafkaVersion.String())
 	env = appendStringIfDefined(env, "AVRO_SCHEMAREGISTRY", context.AvroSchemaRegistry)


### PR DESCRIPTION
# Description

Propagates SASL mechanism setting into the attached K8s pod, making it possible to use `kafkactl attach` in SCRAM-authed clusters.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.md` was updated
- [ ] a usage example was added to `README.md`
