### PR TITLE
extend the documentation of the command completion of zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,15 +174,20 @@ kafkactl completion bash > /usr/local/etc/bash_completion.d/kafkactl
 
 #### zsh
 
+If shell completion is not already enabled in your environment,
+you will need to enable it.  You can execute the following once:
+
 ```
-source <(kafkactl completion zsh)
+echo "autoload -U compinit; compinit" >> ~/.zshrc
 ```
 
 To load completions for each session, execute once:
+
 ```
-kafkactl completion zsh > $ZSH/cache/completions/_kafkactl
-echo '\nautoload -U compinit; compinit' >> ~/.zprofile
+kafkactl completion zsh > "${fpath[1]}/_kafkactl"
 ```
+
+You will need to start a new shell for this setup to take effect.
 
 #### Fish
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ source <(kafkactl completion zsh)
 
 To load completions for each session, execute once:
 ```
-kafkactl completion zsh > "${fpath[1]}/_kafkactl"
+kafkactl completion zsh > $ZSH/cache/completions/_kafkactl
+echo '\nautoload -U compinit; compinit' >> ~/.zprofile
 ```
 
 #### Fish


### PR DESCRIPTION
# Description

In the documentation is a little mistake about the zsh completion. The documentation of zsh recommends installing all completions to the `$ZSH/cache/completions` directory and reloading the completion plugin. The file `.zprofile` is executed in every new terminal session. So every time the completion is activated. It's more explicit.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## Documentation
- [x] fix the zsh completion in`README.md`
