### PR TITLE
Ensure a lowercase name is used when creating the kafkactl pod

### DIFF
--- a/internal/k8s/executor.go
+++ b/internal/k8s/executor.go
@@ -111,7 +111,7 @@ func (kubectl *executor) Run(dockerImageType, entryPoint string, kafkactlArgs []
 	podName := "kafkactl-" + randomString(10)
 
 	if kubectl.clientID != "" {
-		podName = "kafkactl-" + kubectl.clientID
+		podName = "kafkactl-" + strings.ToLower(kubectl.clientID)
 	}
 
 	kubectlArgs := []string{


### PR DESCRIPTION
# Description

When generating the kafkactl pod name the `ClientId` is used and this defaults to the username. The username may contain capital letters which is illegal when naming a pod.

This change ensures that a valid name is used.

This issue can be worked around by explicitly setting `clientID` in the YAML configuration, however this is slightly annoying.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


## Documentation

- [ ] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.md` was updated
- [ ] a usage example was added to `README.md`
