### PR TITLE
add config options to run in kubernetes with a private registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- add config options `image`, `imagePullSecret` in order to pull kafkactl from private registry when running in k8s (fixes #116).
+
 ## 2.0.1 - 2022-01-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ contexts:
       kubeConfig: ~/.kube/config #optional
       kubeContext: my-cluster
       namespace: my-namespace
+      # optional: docker image to use (tag will be added by kafkactl based on the current version) 
+      image: private.registry.com/deviceinsight/kafkactl
+      # optional: secret for private docker registry
+      imagePullSecret: registry-secret
 
     # optional: clientID config (defaults to kafkactl-{username})
     clientID: my-client-id

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -55,7 +55,7 @@ $ kafkactl completion fish > ~/.config/fish/completions/kafkactl.fish
 			case "powershell":
 				err = cmd.Root().GenPowerShellCompletion(os.Stdout)
 			default:
-				err = errors.Errorf("Unsupported shell type %q.", args[0])
+				err = errors.Errorf("unsupported shell type %q", args[0])
 			}
 
 			if err != nil {

--- a/internal/common-operation.go
+++ b/internal/common-operation.go
@@ -38,11 +38,13 @@ type TLSConfig struct {
 }
 
 type K8sConfig struct {
-	Enabled     bool
-	Binary      string
-	KubeConfig  string
-	KubeContext string
-	Namespace   string
+	Enabled         bool
+	Binary          string
+	KubeConfig      string
+	KubeContext     string
+	Namespace       string
+	Image           string
+	ImagePullSecret string
 }
 
 type ProducerConfig struct {
@@ -119,6 +121,8 @@ func CreateClientContext() (ClientContext, error) {
 	context.Kubernetes.KubeConfig = viper.GetString("contexts." + context.Name + ".kubernetes.kubeConfig")
 	context.Kubernetes.KubeContext = viper.GetString("contexts." + context.Name + ".kubernetes.kubeContext")
 	context.Kubernetes.Namespace = viper.GetString("contexts." + context.Name + ".kubernetes.namespace")
+	context.Kubernetes.Image = viper.GetString("contexts." + context.Name + ".kubernetes.image")
+	context.Kubernetes.ImagePullSecret = viper.GetString("contexts." + context.Name + ".kubernetes.imagePullSecret")
 
 	return context, nil
 }

--- a/internal/k8s/executer_test.go
+++ b/internal/k8s/executer_test.go
@@ -1,0 +1,92 @@
+package k8s_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/deviceinsight/kafkactl/internal"
+	"github.com/deviceinsight/kafkactl/internal/k8s"
+	"github.com/deviceinsight/kafkactl/testutil"
+)
+
+type TestRunner struct {
+	binary string
+	args   []string
+}
+
+func (runner *TestRunner) ExecuteAndReturn(binary string, args []string) ([]byte, error) {
+	runner.binary = binary
+	runner.args = args
+	return nil, nil
+}
+
+func (runner *TestRunner) Execute(binary string, args []string) error {
+	runner.binary = binary
+	runner.args = args
+	return nil
+}
+
+func TestExecWithImageAndImagePullSecretProvided(t *testing.T) {
+
+	var context internal.ClientContext
+	context.Kubernetes.Image = "private.registry.com/deviceinsight/kafkactl"
+	context.Kubernetes.ImagePullSecret = "registry-secret"
+
+	var testRunner = TestRunner{}
+	var runner k8s.Runner = &testRunner
+
+	exec := k8s.NewExecutor(context, &runner)
+
+	err := exec.Run("scratch", "/kafkactl", []string{"version"}, []string{"ENV_A=1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	image := extractParam(t, testRunner.args, "--image")
+	if image != context.Kubernetes.Image+":latest-scratch" {
+		t.Fatalf("wrong image: %s", image)
+	}
+
+	overrides := extractParam(t, testRunner.args, "--overrides")
+	var podOverrides k8s.PodOverrideType
+	if err := json.Unmarshal([]byte(overrides), &podOverrides); err != nil {
+		t.Fatalf("unable to unmarshall overrides: %v", err)
+	}
+	if len(podOverrides.Spec.ImagePullSecrets) != 1 || podOverrides.Spec.ImagePullSecrets[0].Name != context.Kubernetes.ImagePullSecret {
+		t.Fatalf("wrong overrides: %s", overrides)
+	}
+}
+
+func TestExecWithImageAndTagFails(t *testing.T) {
+
+	var context internal.ClientContext
+	context.Kubernetes.Image = "private.registry.com/deviceinsight/kafkactl:latest"
+
+	var testRunner = TestRunner{}
+	var runner k8s.Runner = &testRunner
+
+	exec := k8s.NewExecutor(context, &runner)
+
+	err := exec.Run("scratch", "/kafkactl", []string{"version"}, []string{"ENV_A=1"})
+	testutil.AssertErrorContains(t, "image must not contain a tag", err)
+}
+
+func extractParam(t *testing.T, args []string, param string) string {
+
+	var paramIdx int
+
+	if paramIdx = indexOf(param, args); paramIdx < 0 {
+		t.Fatalf("unable to find %s param: %v", param, args)
+	}
+
+	return args[paramIdx+1]
+}
+
+func indexOf(element string, data []string) int {
+	for k, v := range data {
+		if element == v {
+			return k
+		}
+	}
+	return -1
+}

--- a/internal/k8s/export_test.go
+++ b/internal/k8s/export_test.go
@@ -1,3 +1,5 @@
 package k8s
 
 var ParsePodEnvironment = parsePodEnvironment
+
+var NewExecutor = newExecutor

--- a/internal/k8s/k8s-operation.go
+++ b/internal/k8s/k8s-operation.go
@@ -50,7 +50,8 @@ func (operation *Operation) Attach() error {
 		return err
 	}
 
-	exec := newExecutor(operation.context, &ShellRunner{})
+	var runner Runner = &ShellRunner{}
+	exec := newExecutor(operation.context, &runner)
 
 	podEnvironment := parsePodEnvironment(operation.context)
 
@@ -81,7 +82,8 @@ func (operation *Operation) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	exec := newExecutor(operation.context, &ShellRunner{})
+	var runner Runner = &ShellRunner{}
+	exec := newExecutor(operation.context, &runner)
 
 	kafkaCtlCommand := parseCompleteCommand(cmd, []string{})
 	kafkaCtlFlags, err := parseFlags(cmd)
@@ -163,7 +165,10 @@ func parsePodEnvironment(context internal.ClientContext) []string {
 }
 
 func appendStrings(env []string, key string, value []string) []string {
-	return append(env, fmt.Sprintf("%s=%s", key, strings.Join(value, " ")))
+	if len(value) > 0 {
+		return append(env, fmt.Sprintf("%s=%s", key, strings.Join(value, " ")))
+	}
+	return env
 }
 
 func appendBool(env []string, key string, value bool) []string {

--- a/internal/k8s/pod_overrides.go
+++ b/internal/k8s/pod_overrides.go
@@ -1,0 +1,22 @@
+package k8s
+
+type imagePullSecretType struct {
+	Name string `json:"name"`
+}
+
+type specType struct {
+	ImagePullSecrets []imagePullSecretType `json:"imagePullSecrets"`
+}
+
+type PodOverrideType struct {
+	APIVersion string   `json:"apiVersion"`
+	Spec       specType `json:"spec"`
+}
+
+func createPodOverrideForImagePullSecret(imagePullSecret string) PodOverrideType {
+	var override PodOverrideType
+	override.APIVersion = "v1"
+	override.Spec.ImagePullSecrets = make([]imagePullSecretType, 1)
+	override.Spec.ImagePullSecrets[0].Name = imagePullSecret
+	return override
+}

--- a/internal/k8s/runner.go
+++ b/internal/k8s/runner.go
@@ -23,7 +23,7 @@ type ShellRunner struct {
 	Dir string
 }
 
-func (shell ShellRunner) ExecuteAndReturn(binary string, args []string) ([]byte, error) {
+func (shell *ShellRunner) ExecuteAndReturn(binary string, args []string) ([]byte, error) {
 	cmd := exec.Command(binary, args...)
 	cmd.Dir = shell.Dir
 	cmd.Env = os.Environ()
@@ -57,7 +57,7 @@ func (shell ShellRunner) ExecuteAndReturn(binary string, args []string) ([]byte,
 }
 
 // Execute a shell command
-func (shell ShellRunner) Execute(binary string, args []string) error {
+func (shell *ShellRunner) Execute(binary string, args []string) error {
 	cmd := exec.Command(binary, args...)
 	cmd.Dir = shell.Dir
 	cmd.Env = os.Environ()

--- a/internal/producer/producer-operation.go
+++ b/internal/producer/producer-operation.go
@@ -316,7 +316,7 @@ func parsePartitioner(partitioner string, flags Flags) (sarama.PartitionerConstr
 		}
 		return sarama.NewManualPartitioner, nil
 	default:
-		return nil, errors.Errorf("Partitioner %s not supported.", flags.Partitioner)
+		return nil, errors.Errorf("partitioner %s not supported", flags.Partitioner)
 	}
 }
 


### PR DESCRIPTION
# Description

Make docker image configurable and pass dockerPullSecret to container so that the kafkactl image
can be pulled from a private registry

Fixes #116

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [x] the configuration yaml was changed and the example config in `README.md` was updated
