### PR TITLE
Add clone operations, print topic config in json/yaml format with `-c` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - [#105](https://github.com/deviceinsight/kafkactl/issues/105) Add replication factor to `get topics`
 - [#108](https://github.com/deviceinsight/kafkactl/issues/108) Fix "system root pool not available on Windows" by migrating to go 1.19
+- Add `clone` command for `consumer-group` and `topic`
+- Print topic configs when yaml and json output format used with `-c` flag
 
 ## 2.4.0 - 2022-06-23
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -557,6 +557,16 @@ The assigned replicas of a partition can directly be altered with:
 kafkactl alter topic my-topic 3 -r 102,103
 ```
 
+### Clone topic
+
+New topic may be created from existing topic as follows:
+```bash
+kafkactl clone topic source-topic target-topic
+```
+
+Source topic must not exist, target topic must not exist.
+`kafkactl` clones partitions count, replication factor and config entries.
+
 ### Consumer groups
 
 In order to get a list of consumer groups the `get consumer-groups` command can be used:
@@ -597,6 +607,16 @@ kafkactl create consumer-group my-group --topic my-topic --partition 5 --offset 
 # create group for multiple topics with offset for all partitions set to oldest
 kafkactl create consumer-group my-group --topic my-topic-a --topic my-topic-b --oldest
 ```
+
+### Clone consumer group
+
+A consumer group may be created as clone of another consumer group as follows:
+```bash
+kafkactl clone consumer-group source-group target-group
+```
+
+Source group must exist and have committed offsets. Target group must not exist or don't have committed offsets.
+`kafkactl` clones topic assignment and partition offsets.
 
 ### Reset consumer group offsets
 

--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ New topic may be created from existing topic as follows:
 kafkactl clone topic source-topic target-topic
 ```
 
-Source topic must not exist, target topic must not exist.
+Source topic must exist, target topic must not exist.
 `kafkactl` clones partitions count, replication factor and config entries.
 
 ### Consumer groups

--- a/cmd/clone/clone-consumergroup.go
+++ b/cmd/clone/clone-consumergroup.go
@@ -1,0 +1,29 @@
+package clone
+
+import (
+	"github.com/deviceinsight/kafkactl/internal/consumergroupoffsets"
+	"github.com/deviceinsight/kafkactl/internal/consumergroups"
+	"github.com/deviceinsight/kafkactl/internal/k8s"
+	"github.com/deviceinsight/kafkactl/output"
+	"github.com/spf13/cobra"
+)
+
+func newCloneConsumerGroupCmd() *cobra.Command {
+
+	var cloneConsumerGroupCmd = &cobra.Command{
+		Use:     "consumer-group SOURCE_GROUP TARGET_GROUP",
+		Aliases: []string{"cg"},
+		Short:   "clone existing consumerGroup with all offsets",
+		Args:    cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			if !(&k8s.Operation{}).TryRun(cmd, args) {
+				if err := (&consumergroupoffsets.ConsumerGroupOffsetOperation{}).CloneConsumerGroup(args[0], args[1]); err != nil {
+					output.Fail(err)
+				}
+			}
+		},
+		ValidArgsFunction: consumergroups.CompleteConsumerGroups,
+	}
+
+	return cloneConsumerGroupCmd
+}

--- a/cmd/clone/clone-consumergroup_test.go
+++ b/cmd/clone/clone-consumergroup_test.go
@@ -1,0 +1,69 @@
+package clone_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/deviceinsight/kafkactl/testutil"
+)
+
+func TestCloneConsumerGroupIntegration(t *testing.T) {
+
+	testutil.StartIntegrationTest(t)
+
+	kafkaCtl := testutil.CreateKafkaCtlCommand()
+
+	topic1 := testutil.CreateTopic(t, "topic1")
+	topic2 := testutil.CreateTopic(t, "topic2")
+	testutil.ProduceMessage(t, topic1, "test-key-1", "test-value-1", 0, 0)
+	testutil.ProduceMessage(t, topic1, "test-key-1", "test-value-1", 0, 1)
+	testutil.ProduceMessage(t, topic1, "test-key-2", "test-value-2a", 0, 2)
+	testutil.ProduceMessage(t, topic2, "test-key-3", "test-value-3", 0, 0)
+	testutil.ProduceMessage(t, topic2, "test-key-3", "test-value-3", 0, 1)
+
+	srcGroup := testutil.CreateConsumerGroup(t, "srcGroup", topic1, topic2)
+	targetGroup := testutil.GetPrefixedName("targetGroup")
+
+	if _, err := kafkaCtl.Execute("clone", "cg", srcGroup, targetGroup); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	testutil.AssertEquals(t, fmt.Sprintf("consumer-group %s cloned to %s", srcGroup, targetGroup), kafkaCtl.GetStdOut())
+
+	testutil.VerifyConsumerGroupOffset(t, targetGroup, topic1, 3)
+	testutil.VerifyConsumerGroupOffset(t, targetGroup, topic2, 2)
+}
+
+func TestCloneNonExistingConsumerGroupIntegration(t *testing.T) {
+
+	testutil.StartIntegrationTest(t)
+
+	kafkaCtl := testutil.CreateKafkaCtlCommand()
+
+	srcGroup := testutil.GetPrefixedName("src-group")
+	dstGroup := testutil.GetPrefixedName("dst-group")
+
+	if _, err := kafkaCtl.Execute("clone", "cg", srcGroup, dstGroup); err != nil {
+		testutil.AssertErrorContains(t, fmt.Sprintf("consumerGroup '%s' does not contain offsets", srcGroup), err)
+	} else {
+		t.Fatalf("Expected clone operation to fail")
+	}
+}
+
+func TestCloneToExistingConsumerGroupIntegration(t *testing.T) {
+
+	testutil.StartIntegrationTest(t)
+
+	kafkaCtl := testutil.CreateKafkaCtlCommand()
+
+	topic := testutil.CreateTopic(t, "topic")
+
+	srcGroup := testutil.CreateConsumerGroup(t, "src-group", topic)
+	dstGroup := testutil.CreateConsumerGroup(t, "dst-group", topic)
+
+	if _, err := kafkaCtl.Execute("clone", "cg", srcGroup, dstGroup); err != nil {
+		testutil.AssertErrorContains(t, fmt.Sprintf("consumerGroup '%s' contains offsets", dstGroup), err)
+	} else {
+		t.Fatalf("Expected clone operation to fail")
+	}
+}

--- a/cmd/clone/clone-topic.go
+++ b/cmd/clone/clone-topic.go
@@ -1,0 +1,27 @@
+package clone
+
+import (
+	"github.com/deviceinsight/kafkactl/internal/k8s"
+	"github.com/deviceinsight/kafkactl/internal/topic"
+	"github.com/deviceinsight/kafkactl/output"
+	"github.com/spf13/cobra"
+)
+
+func newCloneTopicCmd() *cobra.Command {
+
+	var cloneTopicCmd = &cobra.Command{
+		Use:   "topic SOURCE_TOPIC TARGET_TOPIC",
+		Short: "clone existing topic (number of partitions, replication factor, config entries) to new one",
+		Args:  cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			if !(&k8s.Operation{}).TryRun(cmd, args) {
+				if err := (&topic.Operation{}).CloneTopic(args[0], args[1]); err != nil {
+					output.Fail(err)
+				}
+			}
+		},
+		ValidArgsFunction: topic.CompleteTopicNames,
+	}
+
+	return cloneTopicCmd
+}

--- a/cmd/clone/clone-topic_test.go
+++ b/cmd/clone/clone-topic_test.go
@@ -1,0 +1,106 @@
+package clone_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Rican7/retry"
+	"github.com/Rican7/retry/backoff"
+	"github.com/Rican7/retry/strategy"
+	"gopkg.in/errgo.v2/fmt/errors"
+
+	"github.com/deviceinsight/kafkactl/internal/topic"
+	"github.com/deviceinsight/kafkactl/testutil"
+)
+
+func TestCloneTopicIntegration(t *testing.T) {
+
+	testutil.StartIntegrationTest(t)
+
+	kafkaCtl := testutil.CreateKafkaCtlCommand()
+
+	srcTopic := testutil.CreateTopic(t, "src-topic", "-p", "2", "-r", "3", "-c", "retention.ms=86400000")
+	targetTopic := testutil.GetPrefixedName("target-topic")
+
+	if _, err := kafkaCtl.Execute("clone", "topic", srcTopic, targetTopic); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	testutil.AssertEquals(t, fmt.Sprintf("topic %s cloned to %s", srcTopic, targetTopic), kafkaCtl.GetStdOut())
+
+	getTopic := func(attempt uint) error {
+		_, err := kafkaCtl.Execute("describe", "topic", targetTopic, "-o", "yaml")
+
+		if err != nil {
+			return err
+		}
+		topic, err := topic.FromYaml(kafkaCtl.GetStdOut())
+		if err != nil {
+			return err
+		}
+		if len(topic.Partitions) != 2 {
+			return errors.Newf("only the following partitions present: %v", topic.Partitions)
+		}
+
+		if len(topic.Partitions[0].Replicas) != 3 || len(topic.Partitions[1].Replicas) != 3 {
+			return errors.Newf("replication factor is not 3: %v", topic.Partitions)
+		}
+
+		var retention string
+		for _, configEntry := range topic.Configs {
+			if configEntry.Name == "retention.ms" {
+				retention = configEntry.Value
+				break
+			}
+		}
+
+		if retention != "86400000" {
+			return errors.Newf("topic retention is not 86400000: %v", retention)
+		}
+
+		return nil
+	}
+
+	err := retry.Retry(
+		getTopic,
+		strategy.Limit(5),
+		strategy.Backoff(backoff.Linear(10*time.Millisecond)),
+	)
+
+	if err != nil {
+		t.Fatalf("could not get topic %s: %v", targetTopic, err)
+	}
+}
+
+func TestCloneNonExistingTopicIntegration(t *testing.T) {
+
+	testutil.StartIntegrationTest(t)
+
+	kafkaCtl := testutil.CreateKafkaCtlCommand()
+
+	srcTopic := testutil.GetPrefixedName("src-topic")
+	targetTopic := testutil.GetPrefixedName("target-topic")
+
+	if _, err := kafkaCtl.Execute("clone", "topic", srcTopic, targetTopic); err != nil {
+		testutil.AssertErrorContains(t, fmt.Sprintf("topic '%s' does not exist", srcTopic), err)
+	} else {
+		t.Fatalf("Expected clone operation to fail")
+	}
+}
+
+func TestCloneToExistingTopicIntegration(t *testing.T) {
+
+	testutil.StartIntegrationTest(t)
+
+	kafkaCtl := testutil.CreateKafkaCtlCommand()
+
+	srcTopic := testutil.CreateTopic(t, "src-topic")
+	targetTopic := testutil.CreateTopic(t, "target-topic")
+
+	if _, err := kafkaCtl.Execute("clone", "topic", srcTopic, targetTopic); err != nil {
+		testutil.AssertErrorContains(t, fmt.Sprintf("topic '%s' already exists", targetTopic), err)
+	} else {
+		t.Fatalf("Expected clone operation to fail")
+	}
+}

--- a/cmd/clone/clone.go
+++ b/cmd/clone/clone.go
@@ -1,0 +1,16 @@
+package clone
+
+import "github.com/spf13/cobra"
+
+func NewCloneCmd() *cobra.Command {
+
+	var cmdClone = &cobra.Command{
+		Use:   "clone",
+		Short: "clone topics, consumerGroups",
+	}
+
+	cmdClone.AddCommand(newCloneTopicCmd())
+	cmdClone.AddCommand(newCloneConsumerGroupCmd())
+
+	return cmdClone
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/deviceinsight/kafkactl/cmd/alter"
 	"github.com/deviceinsight/kafkactl/cmd/attach"
+	"github.com/deviceinsight/kafkactl/cmd/clone"
 	"github.com/deviceinsight/kafkactl/cmd/config"
 	"github.com/deviceinsight/kafkactl/cmd/consume"
 	"github.com/deviceinsight/kafkactl/cmd/create"
@@ -52,6 +53,7 @@ func NewKafkactlCommand(streams output.IOStreams) *cobra.Command {
 	rootCmd.AddCommand(produce.NewProduceCmd())
 	rootCmd.AddCommand(reset.NewResetCmd())
 	rootCmd.AddCommand(attach.NewAttachCmd())
+	rootCmd.AddCommand(clone.NewCloneCmd())
 	rootCmd.AddCommand(newCompletionCmd())
 	rootCmd.AddCommand(newVersionCmd())
 	rootCmd.AddCommand(newDocsCmd())

--- a/internal/consumergroupoffsets/OffsetResettingConsumer.go
+++ b/internal/consumergroupoffsets/OffsetResettingConsumer.go
@@ -1,0 +1,164 @@
+package consumergroupoffsets
+
+import (
+	"strconv"
+
+	"github.com/Shopify/sarama"
+	"github.com/deviceinsight/kafkactl/output"
+	"github.com/pkg/errors"
+)
+
+type partitionOffsets struct {
+	Partition     int32
+	OldestOffset  int64 `json:"oldestOffset" yaml:"oldestOffset"`
+	NewestOffset  int64 `json:"newestOffset" yaml:"newestOffset"`
+	CurrentOffset int64 `json:"currentOffset" yaml:"currentOffset"`
+	TargetOffset  int64 `json:"targetOffset" yaml:"targetOffset"`
+}
+
+type OffsetResettingConsumer struct {
+	ready     chan bool
+	client    sarama.Client
+	groupName string
+	topicName string
+	flags     ResetConsumerGroupOffsetFlags
+}
+
+func (consumer *OffsetResettingConsumer) Setup(session sarama.ConsumerGroupSession) error {
+
+	flags := consumer.flags
+
+	// admin.ListConsumerGroupOffsets(group, nil) can be used to fetch the offsets when
+	// https://github.com/Shopify/sarama/pull/1374 is merged
+	coordinator, err := consumer.client.Coordinator(consumer.groupName)
+	if err != nil {
+		return errors.Wrap(err, "failed to get coordinator")
+	}
+
+	request := &sarama.OffsetFetchRequest{
+		// this will only work starting from version 0.10.2.0
+		Version:       2,
+		ConsumerGroup: consumer.groupName,
+	}
+
+	groupOffsets, err := coordinator.FetchOffset(request)
+	if err != nil {
+		return errors.Wrap(err, "failed to get fetch group offsets")
+	}
+
+	offsets := make([]partitionOffsets, 0)
+
+	if flags.Partition > -1 {
+		offset, err := resetOffset(consumer.client, consumer.topicName, flags.Partition, flags, groupOffsets, session)
+		if err != nil {
+			return err
+		}
+		offsets = append(offsets, offset)
+	} else {
+
+		partitions, err := consumer.client.Partitions(consumer.topicName)
+		if err != nil {
+			return errors.Wrap(err, "failed to list partitions")
+		}
+
+		for _, partition := range partitions {
+			offset, err := resetOffset(consumer.client, consumer.topicName, partition, flags, groupOffsets, session)
+			if err != nil {
+				return err
+			}
+			offsets = append(offsets, offset)
+		}
+	}
+
+	if flags.OutputFormat != "" {
+		if err := output.PrintObject(offsets, flags.OutputFormat); err != nil {
+			return err
+		}
+	} else {
+		tableWriter := output.CreateTableWriter()
+		if err := tableWriter.WriteHeader("PARTITION", "OLDEST_OFFSET", "NEWEST_OFFSET", "CURRENT_OFFSET", "TARGET_OFFSET"); err != nil {
+			return err
+		}
+		for _, o := range offsets {
+			if err := tableWriter.Write(strconv.FormatInt(int64(o.Partition), 10),
+				strconv.FormatInt(o.OldestOffset, 10), strconv.FormatInt(o.NewestOffset, 10),
+				strconv.FormatInt(o.CurrentOffset, 10), strconv.FormatInt(o.TargetOffset, 10)); err != nil {
+				return err
+			}
+		}
+		if err := tableWriter.Flush(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (consumer *OffsetResettingConsumer) Cleanup(sarama.ConsumerGroupSession) error {
+	close(consumer.ready)
+	return nil
+}
+
+func (consumer *OffsetResettingConsumer) ConsumeClaim(sarama.ConsumerGroupSession, sarama.ConsumerGroupClaim) error {
+	return nil
+}
+
+func resetOffset(client sarama.Client, topic string, partition int32, flags ResetConsumerGroupOffsetFlags, groupOffsets *sarama.OffsetFetchResponse, session sarama.ConsumerGroupSession) (partitionOffsets, error) {
+	offset, err := getPartitionOffsets(client, topic, partition, flags)
+	if err != nil {
+		return offset, err
+	}
+
+	offset.CurrentOffset = getGroupOffset(groupOffsets, topic, partition)
+
+	if flags.Execute {
+		if offset.TargetOffset > offset.CurrentOffset {
+			session.MarkOffset(topic, partition, offset.TargetOffset, "")
+		} else if offset.TargetOffset < offset.CurrentOffset {
+			session.ResetOffset(topic, partition, offset.TargetOffset, "")
+		}
+	}
+
+	return offset, nil
+}
+
+func getPartitionOffsets(client sarama.Client, topic string, partition int32, flags ResetConsumerGroupOffsetFlags) (partitionOffsets, error) {
+
+	var err error
+	offsets := partitionOffsets{Partition: partition}
+
+	if offsets.OldestOffset, err = client.GetOffset(topic, partition, sarama.OffsetOldest); err != nil {
+		return offsets, errors.Errorf("failed to get offset for topic %s Partition %d: %v", topic, partition, err)
+	}
+
+	if offsets.NewestOffset, err = client.GetOffset(topic, partition, sarama.OffsetNewest); err != nil {
+		return offsets, errors.Errorf("failed to get offset for topic %s Partition %d: %v", topic, partition, err)
+	}
+
+	if flags.Offset > -1 {
+		if flags.Offset < offsets.OldestOffset {
+			return offsets, errors.Errorf("cannot set offset for Partition %d: offset (%d) < oldest offset (%d)", partition, flags.Offset, offsets.OldestOffset)
+		} else if flags.Offset > offsets.NewestOffset {
+			return offsets, errors.Errorf("cannot set offset for Partition %d: offset (%d) > newest offset (%d)", partition, flags.Offset, offsets.NewestOffset)
+		} else {
+			offsets.TargetOffset = flags.Offset
+		}
+	} else {
+		if flags.OldestOffset {
+			offsets.TargetOffset = offsets.OldestOffset
+		} else if flags.NewestOffset {
+			offsets.TargetOffset = offsets.NewestOffset
+		} else {
+			return offsets, errors.New("either offset,oldest,newest parameter needs to be specified")
+		}
+	}
+
+	return offsets, nil
+}
+
+func getGroupOffset(offsetFetchResponse *sarama.OffsetFetchResponse, topic string, partition int32) int64 {
+	block := offsetFetchResponse.Blocks[topic][partition]
+	if block != nil {
+		return block.Offset
+	}
+	return -1
+}

--- a/internal/consumergroupoffsets/OffsetSettingConsumer.go
+++ b/internal/consumergroupoffsets/OffsetSettingConsumer.go
@@ -1,0 +1,29 @@
+package consumergroupoffsets
+
+import "github.com/Shopify/sarama"
+
+type OffsetSettingConsumer struct {
+	Topic            string
+	PartitionOffsets map[int32]PartitionOffset
+
+	ready chan struct{}
+}
+
+func (s *OffsetSettingConsumer) Setup(session sarama.ConsumerGroupSession) error {
+	s.ready = make(chan struct{})
+
+	for partition, offset := range s.PartitionOffsets {
+		session.MarkOffset(s.Topic, partition, offset.Offset, offset.Metadata)
+	}
+
+	return nil
+}
+
+func (s *OffsetSettingConsumer) Cleanup(sarama.ConsumerGroupSession) error {
+	close(s.ready)
+	return nil
+}
+
+func (s *OffsetSettingConsumer) ConsumeClaim(sarama.ConsumerGroupSession, sarama.ConsumerGroupClaim) error {
+	return nil
+}

--- a/internal/topic/topic-operation.go
+++ b/internal/topic/topic-operation.go
@@ -170,26 +170,26 @@ func (operation *Operation) DescribeTopic(topic string, flags DescribeTopicFlags
 
 func (operation *Operation) printTopic(topic Topic, flags DescribeTopicFlags) error {
 
-	if flags.PrintConfigs {
-		if flags.OutputFormat == "json" || flags.OutputFormat == "yaml" {
-			topic.Configs = nil
-		} else {
-			configTableWriter := output.CreateTableWriter()
-			if err := configTableWriter.WriteHeader("CONFIG", "VALUE"); err != nil {
-				return err
-			}
+	if !flags.PrintConfigs {
+		topic.Configs = nil
+	}
 
-			for _, c := range topic.Configs {
-				if err := configTableWriter.Write(c.Name, c.Value); err != nil {
-					return err
-				}
-			}
-
-			if err := configTableWriter.Flush(); err != nil {
-				return err
-			}
-			output.PrintStrings("")
+	if len(topic.Configs) != 0 && flags.OutputFormat != "json" && flags.OutputFormat != "yaml" {
+		configTableWriter := output.CreateTableWriter()
+		if err := configTableWriter.WriteHeader("CONFIG", "VALUE"); err != nil {
+			return err
 		}
+
+		for _, c := range topic.Configs {
+			if err := configTableWriter.Write(c.Name, c.Value); err != nil {
+				return err
+			}
+		}
+
+		if err := configTableWriter.Flush(); err != nil {
+			return err
+		}
+		output.PrintStrings("")
 	}
 
 	if flags.SkipEmptyPartitions {
@@ -430,6 +430,74 @@ func (operation *Operation) ListTopicsNames() ([]string, error) {
 	return topics, nil
 }
 
+func (operation *Operation) CloneTopic(sourceTopic, targetTopic string) error {
+
+	var (
+		context internal.ClientContext
+		client  sarama.Client
+		admin   sarama.ClusterAdmin
+		err     error
+		exists  bool
+		t       Topic
+	)
+
+	if context, err = internal.CreateClientContext(); err != nil {
+		return err
+	}
+
+	if client, err = internal.CreateClient(&context); err != nil {
+		return errors.Wrap(err, "failed to create client")
+	}
+
+	if exists, err = internal.TopicExists(&client, sourceTopic); err != nil {
+		return errors.Wrap(err, "failed to read topics")
+	}
+
+	if !exists {
+		return errors.Errorf("topic '%s' does not exist", sourceTopic)
+	}
+
+	if exists, err = internal.TopicExists(&client, targetTopic); err != nil {
+		return errors.Wrap(err, "failed to read topics")
+	}
+
+	if exists {
+		return errors.Errorf("topic '%s' already exists", targetTopic)
+	}
+
+	if admin, err = internal.CreateClusterAdmin(&context); err != nil {
+		return errors.Wrap(err, "failed to create cluster admin")
+	}
+
+	requestedFields := requestedTopicFields{
+		partitionID:       true,
+		partitionReplicas: true,
+		config:            true,
+	}
+
+	if t, err = readTopic(&client, &admin, sourceTopic, requestedFields); err != nil {
+		return errors.Errorf("unable to read topic %s: %v", sourceTopic, err)
+	}
+
+	topicDetail := &sarama.TopicDetail{
+		NumPartitions:     int32(len(t.Partitions)),
+		ReplicationFactor: int16(replicationFactor(t)),
+		ConfigEntries:     make(map[string]*string, len(t.Configs)),
+	}
+
+	for _, configEntry := range t.Configs {
+		topicDetail.ConfigEntries[configEntry.Name] = &configEntry.Value
+	}
+
+	if err = admin.CreateTopic(targetTopic, topicDetail, false); err != nil {
+		return errors.Wrap(err, "failed to create topic")
+	}
+
+	output.Infof("topic %s cloned to %s", sourceTopic, targetTopic)
+
+	return nil
+}
+
 func getTargetReplicas(currentReplicas []int32, brokerReplicaCount map[int32]int, targetReplicationFactor int16) ([]int32, error) {
 
 	replicas := currentReplicas
@@ -558,7 +626,7 @@ func (operation *Operation) GetTopics(flags GetTopicsFlags) error {
 		return output.PrintObject(topicList, flags.OutputFormat)
 	} else if flags.OutputFormat == "wide" {
 		for _, t := range topicList {
-			if err := tableWriter.Write(t.Name, strconv.Itoa(len(t.Partitions)), replicationFactor(t), getConfigString(t.Configs)); err != nil {
+			if err := tableWriter.Write(t.Name, strconv.Itoa(len(t.Partitions)), strconv.Itoa(replicationFactor(t)), getConfigString(t.Configs)); err != nil {
 				return err
 			}
 		}
@@ -570,7 +638,7 @@ func (operation *Operation) GetTopics(flags GetTopicsFlags) error {
 		}
 	} else {
 		for _, t := range topicList {
-			if err := tableWriter.Write(t.Name, strconv.Itoa(len(t.Partitions)), replicationFactor(t)); err != nil {
+			if err := tableWriter.Write(t.Name, strconv.Itoa(len(t.Partitions)), strconv.Itoa(replicationFactor(t))); err != nil {
 				return err
 			}
 		}
@@ -684,7 +752,7 @@ func getConfigString(configs []internal.Config) string {
 }
 
 // replicationFactor for topic calculated as minimal replication factor across partitions.
-func replicationFactor(t Topic) string {
+func replicationFactor(t Topic) int {
 	var factor int
 	for _, partition := range t.Partitions {
 		if len(partition.Replicas) < factor || factor == 0 {
@@ -692,7 +760,7 @@ func replicationFactor(t Topic) string {
 		}
 	}
 
-	return strconv.Itoa(factor)
+	return factor
 }
 
 func CompleteTopicNames(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {


### PR DESCRIPTION
# Description

* Add clone command for consumer groups and topics
* Output topic configuration values in `describe topic` with yaml or json output format and `-c` flag. This used inside integration tests for `clone` operations.

I've decided to implement `clone` because recently we had strange situation with consumer group stuck in `CompletingRebalance` state with "zombie" members (left after session timeout expiration). As workaround we saved group offsets and assignments, created new consumer group and set partition offsets on it to previously saved values. It was long-running operation because we used combo of `jq` and `reset consumer-group-offset` (one command run per topic partition). New command will do this much faster.

- [x] New feature (non-breaking change which adds functionality)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [x] a usage example was added to `README.md`
- [x] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
