### PR TITLE
Add --print-partitions to consume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [#143](https://github.com/deviceinsight/kafkactl/pull/143) Dependencies have been updated
+- [#139](https://github.com/deviceinsight/kafkactl/pull/139) Option to print partitions in default output format
 
 ## 3.0.0 - 2022-09-30
 ### Changed

--- a/README.md
+++ b/README.md
@@ -309,6 +309,11 @@ The following example prints message `key` and `timestamp` as well as `partition
 kafkactl consume my-topic --print-keys --print-timestamps -o yaml
 ```
 
+To print partition in default output format use:
+```bash
+kafkactl consume my-topic --print-partitions
+```
+
 Headers of kafka messages can be printed with the parameter `--print-headers` e.g.:
 ```bash
 kafkactl consume my-topic --print-headers -o yaml

--- a/cmd/consume/consume.go
+++ b/cmd/consume/consume.go
@@ -27,6 +27,7 @@ func NewConsumeCmd() *cobra.Command {
 		ValidArgsFunction: topic.CompleteTopicNames,
 	}
 
+	cmdConsume.Flags().BoolVarP(&flags.PrintPartitions, "print-partitions", "", false, "print message partitions")
 	cmdConsume.Flags().BoolVarP(&flags.PrintKeys, "print-keys", "k", false, "print message keys")
 	cmdConsume.Flags().BoolVarP(&flags.PrintTimestamps, "print-timestamps", "t", false, "print message timestamps")
 	cmdConsume.Flags().BoolVarP(&flags.PrintAvroSchema, "print-schema", "a", false, "print details about avro schema used for decoding")

--- a/cmd/consume/consume_test.go
+++ b/cmd/consume/consume_test.go
@@ -31,6 +31,23 @@ func TestConsumeWithKeyAndValueIntegration(t *testing.T) {
 	testutil.AssertEquals(t, "test-key#test-value", kafkaCtl.GetStdOut())
 }
 
+func TestConsumeWithPartitionAndValueIntegration(t *testing.T) {
+
+	testutil.StartIntegrationTest(t)
+
+	topicName := testutil.CreateTopic(t, "consume-topic", "--partitions", "2")
+
+	testutil.ProduceMessage(t, topicName, "test-key", "test-value", 1, 0)
+
+	kafkaCtl := testutil.CreateKafkaCtlCommand()
+
+	if _, err := kafkaCtl.Execute("consume", topicName, "--from-beginning", "--exit", "--print-partitions"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	testutil.AssertEquals(t, "1#test-value", kafkaCtl.GetStdOut())
+}
+
 func TestConsumeWithEmptyPartitionsIntegration(t *testing.T) {
 
 	testutil.StartIntegrationTest(t)

--- a/internal/consume/AvroMessageDeserializer.go
+++ b/internal/consume/AvroMessageDeserializer.go
@@ -197,7 +197,9 @@ func (deserializer AvroMessageDeserializer) Deserialize(rawMsg *sarama.ConsumerM
 				row = append(row, "")
 			}
 		}
-
+		if flags.PrintPartitions {
+			row = append(row, strconv.Itoa(int(msg.Partition)))
+		}
 		if flags.PrintKeys {
 			if msg.Key != nil {
 				row = append(row, *msg.Key)

--- a/internal/consume/DefaultMessageDeserializer.go
+++ b/internal/consume/DefaultMessageDeserializer.go
@@ -1,6 +1,7 @@
 package consume
 
 import (
+	"strconv"
 	"strings"
 	"time"
 
@@ -68,6 +69,10 @@ func (deserializer DefaultMessageDeserializer) Deserialize(rawMsg *sarama.Consum
 			} else {
 				row = append(row, "")
 			}
+		}
+
+		if flags.PrintPartitions {
+			row = append(row, strconv.Itoa(int(msg.Partition)))
 		}
 
 		if flags.PrintKeys {

--- a/internal/consume/ProtobufMessageDeserializer.go
+++ b/internal/consume/ProtobufMessageDeserializer.go
@@ -1,6 +1,7 @@
 package consume
 
 import (
+	"strconv"
 	"strings"
 	"time"
 
@@ -99,6 +100,10 @@ func (deserializer ProtobufMessageDeserializer) Deserialize(rawMsg *sarama.Consu
 		} else {
 			row = append(row, "")
 		}
+	}
+
+	if flags.PrintPartitions {
+		row = append(row, strconv.Itoa(int(msg.Partition)))
 	}
 
 	if flags.PrintKeys {

--- a/internal/consume/consume-operation.go
+++ b/internal/consume/consume-operation.go
@@ -16,6 +16,7 @@ import (
 )
 
 type Flags struct {
+	PrintPartitions  bool
 	PrintKeys        bool
 	PrintTimestamps  bool
 	PrintAvroSchema  bool


### PR DESCRIPTION
# Description

Add --print-partitions to consume command.

Sometimes you know the key of a message but not the partition. --print-partitions can be useful to discover the partition and run a subsequent query on the relevant partition. It can also be useful when a consumer partitioner is used. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Documentation

- [ ] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.md` was updated
- [ ] a usage example was added to `README.md`
- [x] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
