### PR TITLE
Allow the extra field to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,10 @@ contexts:
       image: private.registry.com/deviceinsight/kafkactl
       # optional: secret for private docker registry
       imagePullSecret: registry-secret
-
+      # optional: extra args to be passed into the kubectl run command
+      extra:
+        - --overrides
+        - '{"spec": { "nodeSelector": {"kubernetes.io/hostname": "eks-staging-4"}}}'
     # optional: clientID config (defaults to kafkactl-{username})
     clientID: my-client-id
     

--- a/internal/common-operation.go
+++ b/internal/common-operation.go
@@ -42,6 +42,7 @@ type TLSConfig struct {
 type K8sConfig struct {
 	Enabled         bool
 	Binary          string
+	Extra           []string
 	KubeConfig      string
 	KubeContext     string
 	Namespace       string
@@ -125,6 +126,7 @@ func CreateClientContext() (ClientContext, error) {
 	context.Kubernetes.KubeConfig = viper.GetString("contexts." + context.Name + ".kubernetes.kubeConfig")
 	context.Kubernetes.KubeContext = viper.GetString("contexts." + context.Name + ".kubernetes.kubeContext")
 	context.Kubernetes.Namespace = viper.GetString("contexts." + context.Name + ".kubernetes.namespace")
+	context.Kubernetes.Extra = viper.GetStringSlice("contexts." + context.Name + ".kubernetes.extra")
 	context.Kubernetes.Image = viper.GetString("contexts." + context.Name + ".kubernetes.image")
 	context.Kubernetes.ImagePullSecret = viper.GetString("contexts." + context.Name + ".kubernetes.imagePullSecret")
 

--- a/internal/k8s/executor.go
+++ b/internal/k8s/executor.go
@@ -97,6 +97,7 @@ func newExecutor(context internal.ClientContext, runner *Runner) *executor {
 		kubeConfig:      context.Kubernetes.KubeConfig,
 		kubeContext:     context.Kubernetes.KubeContext,
 		namespace:       context.Kubernetes.Namespace,
+		extra:           context.Kubernetes.Extra,
 		runner:          runner,
 	}
 }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.
List any dependencies that are required for this change.

Fixes # (issue)
This PR allows the use of the `extra` field that was already present in the executor struct. This will allow for additional run time options to be set in the `kubectl run` command. 

The changes in this PR include:
- read the config value for `extra` and set in the existing executor
- reference the `extra` field in the executor during instantiation
- Update README.md with and example of passing in a nodeSelector patch

This is a non breaking change and takes advantage of the original struct fields. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [ ] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [x] the configuration yaml was changed and the example config in `README.md` was updated
- [x] a usage example was added to `README.md`
- [ ] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
