### PR TITLE
Handle cases where assignment can be nil.

### DIFF
--- a/internal/consumergroups/consumer-group-operation.go
+++ b/internal/consumergroups/consumer-group-operation.go
@@ -454,6 +454,11 @@ func findAssignedTopics(admin sarama.ClusterAdmin, groupNames []string) (map[str
 				return nil, errors.Wrap(err, "failed to get group member assignment")
 			}
 
+			if assignment == nil {
+				output.Warnf("assignment does not exist for member=%s, clientId=%s, group=%s", member.MemberId, member.ClientId, description.GroupId)
+				continue
+			}
+
 			for t := range assignment.Topics {
 				if !util.ContainsString(topics, t) {
 					topics = append(topics, t)


### PR DESCRIPTION
# Description

If the `MemeberAssignment` for a Group Member is of zero length, then [GetMemberAssignment](https://github.com/IBM/sarama/blob/v1.40.1/describe_groups_response.go#L254) returns a `nil` for assignment.

When this happens `assignment` is set to `nil`, which results in a panic.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x178d78a]

goroutine 1 [running]:
github.com/deviceinsight/kafkactl/internal/consumergroups.findAssignedTopics({0x1b39528?, 0xc0007978c0?}, {0xc000af8000?, 0x3e0, 0x1?})
        /home/runner/work/kafkactl/kafkactl/internal/consumergroups/consumer-group-operation.go:457 +0x58a
github.com/deviceinsight/kafkactl/internal/consumergroups.(*ConsumerGroupOperation).GetConsumerGroups(0xc00026fa88?, {{0x0?, 0xc0002af8b0?}, {0x7ff7bfefe94f?, 0x5?}})
        /home/runner/work/kafkactl/kafkactl/internal/consumergroups/consumer-group-operation.go:355 +0x318
github.com/deviceinsight/kafkactl/cmd/get.newGetConsumerGroupsCmd.func1(0xc00040ef00?, {0xc0002af8b0?, 0x5?, 0x5?})
        /home/runner/work/kafkactl/kafkactl/cmd/get/get-consumer-groups.go:22 +0x8e
github.com/spf13/cobra.(*Command).execute(0xc00040ef00, {0xc0002af860, 0x5, 0x5})
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:944 +0x847
github.com/spf13/cobra.(*Command).ExecuteC(0xc0003fe000)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3bd
github.com/spf13/cobra.(*Command).Execute(0x1b26520?)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992 +0x19
main.main()
        /home/runner/work/kafkactl/kafkactl/main.go:28 +0x132
```

The workaround is to do a `continue` if the `assignment` is `nil`, we also provide a warning log when such a case occurs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Documentation

- [ ] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.md` was updated
- [ ] a usage example was added to `README.md`
- [ ] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
