### PR TITLE
Fix  `describe consumer-group` crash when a group member has no assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- [#162](https://github.com/deviceinsight/kafkactl/pull/162) Fix `consumer-group` crash when a group member has no assignment
+- [#162](https://github.com/deviceinsight/kafkactl/pull/162) Fix `consumer-group` crashes when a group member has no assignment
 
 ## 3.2.0 - 2023-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [#162](https://github.com/deviceinsight/kafkactl/pull/162) Fix `consumer-group` crash when a group member has no assignment
 
 ## 3.2.0 - 2023-08-17
 

--- a/internal/consumergroups/consumer-group-operation.go
+++ b/internal/consumergroups/consumer-group-operation.go
@@ -132,6 +132,8 @@ func (operation *ConsumerGroupOperation) DescribeConsumerGroup(flags DescribeCon
 			if err != nil {
 				output.Warnf("failed to get group member assignment (%s, %s): %v", member.ClientHost, member.ClientId, err)
 				assignedPartitions = make(map[string][]int32)
+                       } else if memberAssignment == nil {
+                               output.Warnf("client (host: %s, ID: %s) has no group member assignment", member.ClientHost, member.ClientId)
 			} else {
 				assignedPartitions = filterAssignedPartitions(memberAssignment.Topics, topicPartitions)
 			}


### PR DESCRIPTION
# Description

This is a fairly common state when a new consumer is joining the group, or during a rebalance.

Before:
```
$ ./kafkactl describe consumer-group console-consumer
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xb4336d] 
goroutine 1 [running]:
github.com/deviceinsight/kafkactl/internal/consumergroups.(*ConsumerGroupOperation).DescribeConsumerGroup(0xc000359400?, {0x0, {0x0, 0x0}, {0x0, 0x0}, 0x1, 0x1}, {0x7ffd8470d336, 0x10})
    /home/smuth/go/src/github.com/deviceinsight/kafkactl/internal/consumergroups/consumer-group-operation.go:137 +0xf0d
github.com/deviceinsight/kafkactl/cmd/describe.newDescribeConsumerGroupCmd.func1(0xc000368c00?, {0xc000359400?, 0x1, 0xd14616?})
    /home/smuth/go/src/github.com/deviceinsight/kafkactl/cmd/describe/describe-consumer-group.go:22 +0xbf   
github.com/spf13/cobra.(*Command).execute(0xc000380c00, {0xc0003593d0, 0x1, 0x1})     
    /home/smuth/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:944 +0x863    
github.com/spf13/cobra.(*Command).ExecuteC(0xc0002a4900)
    /home/smuth/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3a5   
github.com/spf13/cobra.(*Command).Execute(0xe9b380?)
    /home/smuth/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992 +0x13
main.main()
        /home/smuth/go/src/github.com/deviceinsight/kafkactl/main.go:28 +0x12a   
```
After:
```
$ ./kafkactl describe consumer-group console-consumer
client (host: /10.20.46.72, ID: console-consumer) has no group member assignment
TOPIC     PARTITION     NEWEST_OFFSET     OLDEST_OFFSET     CONSUMER_OFFSET     LEAD     LAG                                            
test      0             0                 0                 0                   0        0                                              
test      1             22                0                 22                  22       0
...etc...
```

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`

