### PR TITLE
fix kubectl version detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - [#162](https://github.com/deviceinsight/kafkactl/pull/162) Fix `consumer-group` crashes when a group member has no assignment
+- [#160](https://github.com/deviceinsight/kafkactl/pull/160) Fix kubectl version detection
 
+### Added
 - [#159](https://github.com/deviceinsight/kafkactl/issues/159) Add ability to read config file from `$PWD/kafkactl.yml` 
 
 ## 3.2.0 - 2023-08-17

--- a/internal/k8s/executer_test.go
+++ b/internal/k8s/executer_test.go
@@ -2,7 +2,10 @@ package k8s_test
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
+
+	"github.com/deviceinsight/kafkactl/output"
 
 	"github.com/deviceinsight/kafkactl/internal"
 	"github.com/deviceinsight/kafkactl/internal/k8s"
@@ -10,14 +13,15 @@ import (
 )
 
 type TestRunner struct {
-	binary string
-	args   []string
+	binary   string
+	args     []string
+	response []byte
 }
 
 func (runner *TestRunner) ExecuteAndReturn(binary string, args []string) ([]byte, error) {
 	runner.binary = binary
 	runner.args = args
-	return nil, nil
+	return runner.response, nil
 }
 
 func (runner *TestRunner) Execute(binary string, args []string) error {
@@ -52,7 +56,8 @@ func TestExecWithImageAndImagePullSecretProvided(t *testing.T) {
 	if err := json.Unmarshal([]byte(overrides), &podOverrides); err != nil {
 		t.Fatalf("unable to unmarshall overrides: %v", err)
 	}
-	if len(podOverrides.Spec.ImagePullSecrets) != 1 || podOverrides.Spec.ImagePullSecrets[0].Name != context.Kubernetes.ImagePullSecret {
+	if len(podOverrides.Spec.ImagePullSecrets) != 1 ||
+		podOverrides.Spec.ImagePullSecrets[0].Name != context.Kubernetes.ImagePullSecret {
 		t.Fatalf("wrong overrides: %s", overrides)
 	}
 }
@@ -69,6 +74,91 @@ func TestExecWithImageAndTagFails(t *testing.T) {
 
 	err := exec.Run("scratch", "/kafkactl", []string{"version"}, []string{"ENV_A=1"})
 	testutil.AssertErrorContains(t, "image must not contain a tag", err)
+}
+
+//nolint:gocognit
+func TestParseKubectlVersion(t *testing.T) {
+
+	var testRunner = TestRunner{}
+	var runner k8s.Runner = &testRunner
+
+	type tests struct {
+		description   string
+		kubectlOutput string
+		wantErr       string
+		wantVersion   k8s.Version
+	}
+
+	for _, test := range []tests{
+		{
+			description:   "parse_fails_for_unparsable_output",
+			kubectlOutput: "unknown output",
+			wantErr:       "unable to extract kubectl version",
+		},
+		{
+			description: "parse_valid_kubectl_output_succeeds",
+			kubectlOutput: `
+				{
+				  "ClientVersion": {
+					"major": "1",
+					"minor": "27",
+					"gitVersion": "v1.27.1",
+					"gitCommit": "4c9411232e10168d7b050c49a1b59f6df9d7ea4b",
+					"gitTreeState": "clean",
+					"buildDate": "2023-04-14T13:14:41Z",
+					"goVersion": "go1.20.3",
+					"compiler": "gc",
+					"platform": "linux/amd64"
+				  },
+				  "kustomizeVersion": "v5.0.1"
+				}`,
+			wantVersion: k8s.Version{
+				Major:      1,
+				Minor:      27,
+				GitVersion: "v1.27.1",
+			},
+		},
+	} {
+		t.Run(test.description, func(t *testing.T) {
+
+			var err error
+
+			output.Fail = func(failError error) {
+				err = failError
+			}
+
+			testRunner.response = []byte(test.kubectlOutput)
+
+			version := k8s.GetKubectlVersion("kubectl", &runner)
+
+			if test.wantErr != "" {
+				if err == nil {
+					t.Errorf("want error %q but got nil", test.wantErr)
+				}
+
+				if !strings.Contains(err.Error(), test.wantErr) {
+					t.Errorf("want error %q got %q", test.wantErr, err)
+				}
+
+				return
+			}
+			if err != nil {
+				t.Errorf("doesn't want error but got %s", err)
+			}
+
+			if test.wantVersion.GitVersion != version.GitVersion {
+				t.Fatalf("different version expexted %s != %s", test.wantVersion.GitVersion, version.GitVersion)
+			}
+
+			if test.wantVersion.Major != version.Major {
+				t.Fatalf("different major version expexted %d != %d", test.wantVersion.Major, version.Major)
+			}
+
+			if test.wantVersion.Minor != version.Minor {
+				t.Fatalf("different minor version expexted %d != %d", test.wantVersion.Minor, version.Minor)
+			}
+		})
+	}
 }
 
 func extractParam(t *testing.T, args []string, param string) string {

--- a/internal/k8s/export_test.go
+++ b/internal/k8s/export_test.go
@@ -2,4 +2,6 @@ package k8s
 
 var ParsePodEnvironment = parsePodEnvironment
 
+var GetKubectlVersion = getKubectlVersion
+
 var NewExecutor = newExecutor


### PR DESCRIPTION
# Description

Fix kubectl version detection after kubectl version output changes.

Fixes #160 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [x] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
