### PR TITLE
Kubernetes pod name now always includes random suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- [#165](https://github.com/deviceinsight/kafkactl/issues/165) Kubernetes pod name now always includes random suffix 
+
 ## 3.3.0 - 2023-09-05
 ### Fixed
 - [#162](https://github.com/deviceinsight/kafkactl/pull/162) Fix `consumer-group` crashes when a group member has no assignment

--- a/internal/k8s/executor.go
+++ b/internal/k8s/executor.go
@@ -119,11 +119,7 @@ func (kubectl *executor) Run(dockerImageType, entryPoint string, kafkactlArgs []
 		return err
 	}
 
-	podName := "kafkactl-" + randomString(10)
-
-	if kubectl.clientID != "" {
-		podName = "kafkactl-" + strings.ToLower(kubectl.clientID)
-	}
+	podName := fmt.Sprintf("kafkactl-%s-%s", strings.ToLower(kubectl.clientID), randomString(4))
 
 	kubectlArgs := []string{
 		"run", "--rm", "-i", "--tty", "--restart=Never", podName,


### PR DESCRIPTION
# Description

Always append a random suffix to pod name to ensure multiple kafkactl pods can run in parallel

Fixes #165 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`

