### PR TITLE
Add include defaults when describing topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- [#184](https://github.com/deviceinsight/kafkactl/pull/184) Added option to show default configs when describing topics
+
 ## 3.5.1 - 2023-11-10
 
 ## 3.5.0 - 2023-11-10

--- a/cmd/describe/describe-topic.go
+++ b/cmd/describe/describe-topic.go
@@ -26,9 +26,8 @@ func newDescribeTopicCmd() *cobra.Command {
 	}
 
 	cmdDescribeTopic.Flags().StringVarP(&flags.OutputFormat, "output", "o", flags.OutputFormat, "output format. One of: json|yaml|wide")
-	cmdDescribeTopic.Flags().BoolVarP(&flags.PrintConfigs, "print-configs", "c", true, "print configs")
+	cmdDescribeTopic.Flags().StringVarP((*string)(&flags.PrintConfigs), "print-configs", "c", "no_defaults", "print configs. One of none|no_defaults|all")
 	cmdDescribeTopic.Flags().BoolVarP(&flags.SkipEmptyPartitions, "skip-empty", "s", false, "show only partitions that have a messages")
-	cmdDescribeTopic.Flags().BoolVarP(&flags.IncludeDefaults, "include-defaults", "i", false, "include default configs")
 
 	return cmdDescribeTopic
 }

--- a/cmd/describe/describe-topic.go
+++ b/cmd/describe/describe-topic.go
@@ -28,6 +28,7 @@ func newDescribeTopicCmd() *cobra.Command {
 	cmdDescribeTopic.Flags().StringVarP(&flags.OutputFormat, "output", "o", flags.OutputFormat, "output format. One of: json|yaml|wide")
 	cmdDescribeTopic.Flags().BoolVarP(&flags.PrintConfigs, "print-configs", "c", true, "print configs")
 	cmdDescribeTopic.Flags().BoolVarP(&flags.SkipEmptyPartitions, "skip-empty", "s", false, "show only partitions that have a messages")
+	cmdDescribeTopic.Flags().BoolVarP(&flags.IncludeDefaults, "include-defaults", "i", false, "include default configs")
 
 	return cmdDescribeTopic
 }

--- a/cmd/describe/describe-topic_test.go
+++ b/cmd/describe/describe-topic_test.go
@@ -4,8 +4,68 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/deviceinsight/kafkactl/internal"
+	"github.com/deviceinsight/kafkactl/internal/topic"
+
 	"github.com/deviceinsight/kafkactl/testutil"
 )
+
+func TestDescribeTopicConfigsIntegration(t *testing.T) {
+
+	testutil.StartIntegrationTest(t)
+
+	prefix := "describe-t-configs-"
+
+	topicName1 := testutil.CreateTopic(t, prefix, "--config", "retention.ms=3600000")
+
+	kafkaCtl := testutil.CreateKafkaCtlCommand()
+	kafkaCtl.Verbose = false
+
+	// default --print-configs=no_defaults
+	if _, err := kafkaCtl.Execute("describe", "topic", topicName1, "-o", "yaml"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	describedTopic, err := topic.FromYaml(kafkaCtl.GetStdOut())
+	if err != nil {
+		t.Fatalf("failed to read yaml: %v", err)
+	}
+
+	configKeys := getConfigKeys(describedTopic.Configs)
+
+	testutil.AssertArraysEquals(t, []string{"retention.ms"}, configKeys)
+	testutil.AssertEquals(t, "3600000", describedTopic.Configs[0].Value)
+
+	// explicitly without defaults
+	if _, err := kafkaCtl.Execute("describe", "topic", topicName1, "-c", "no_defaults", "-o", "yaml"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	describedTopic, err = topic.FromYaml(kafkaCtl.GetStdOut())
+	if err != nil {
+		t.Fatalf("failed to read yaml: %v", err)
+	}
+
+	configKeys = getConfigKeys(describedTopic.Configs)
+
+	testutil.AssertArraysEquals(t, []string{"retention.ms"}, configKeys)
+	testutil.AssertEquals(t, "3600000", describedTopic.Configs[0].Value)
+
+	// all configs
+	if _, err := kafkaCtl.Execute("describe", "topic", topicName1, "-c", "all", "-o", "yaml"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	describedTopic, err = topic.FromYaml(kafkaCtl.GetStdOut())
+	if err != nil {
+		t.Fatalf("failed to read yaml: %v", err)
+	}
+
+	configKeys = getConfigKeys(describedTopic.Configs)
+
+	testutil.AssertContains(t, "retention.ms", configKeys)
+	testutil.AssertContains(t, "cleanup.policy", configKeys)
+}
 
 func TestDescribeTopicAutoCompletionIntegration(t *testing.T) {
 
@@ -29,4 +89,12 @@ func TestDescribeTopicAutoCompletionIntegration(t *testing.T) {
 	testutil.AssertContains(t, topicName1, outputLines)
 	testutil.AssertContains(t, topicName2, outputLines)
 	testutil.AssertContains(t, topicName3, outputLines)
+}
+
+func getConfigKeys(configs []internal.Config) []string {
+	keys := make([]string, len(configs))
+	for i, config := range configs {
+		keys[i] = config.Name
+	}
+	return keys
 }

--- a/internal/broker/broker-operation.go
+++ b/internal/broker/broker-operation.go
@@ -77,7 +77,7 @@ func (operation *Operation) GetBrokers(flags GetBrokersFlags) error {
 			Name: fmt.Sprint(broker.ID()),
 		}
 
-		if configs, err = internal.ListConfigs(&admin, brokerConfig); err != nil {
+		if configs, err = internal.ListConfigs(&admin, brokerConfig, false); err != nil {
 			return err
 		}
 
@@ -153,7 +153,7 @@ func (operation *Operation) DescribeBroker(id int32, flags DescribeBrokerFlags) 
 		Name: fmt.Sprint(broker.ID()),
 	}
 
-	if configs, err = internal.ListConfigs(&admin, brokerConfig); err != nil {
+	if configs, err = internal.ListConfigs(&admin, brokerConfig, false); err != nil {
 		return err
 	}
 

--- a/internal/common-operation.go
+++ b/internal/common-operation.go
@@ -323,7 +323,9 @@ func ListConfigs(admin *sarama.ClusterAdmin, resource sarama.ConfigResource, inc
 	return listConfigsFromEntries(configEntries, includeDefaults), nil
 }
 
-func listConfigsFromEntries(configEntries []sarama.ConfigEntry, includeDefaults bool) (configs []Config) {
+func listConfigsFromEntries(configEntries []sarama.ConfigEntry, includeDefaults bool) []Config {
+	var configs = make([]Config, 0)
+
 	for _, configEntry := range configEntries {
 
 		if includeDefaults || (!configEntry.Default && configEntry.Source != sarama.SourceDefault) {
@@ -332,7 +334,7 @@ func listConfigsFromEntries(configEntries []sarama.ConfigEntry, includeDefaults 
 		}
 	}
 
-	return
+	return configs
 }
 
 func getResourceTypeName(resourceType sarama.ConfigResourceType) string {

--- a/internal/common-operation.go
+++ b/internal/common-operation.go
@@ -309,10 +309,9 @@ func TopicExists(client *sarama.Client, name string) (bool, error) {
 	return false, nil
 }
 
-func ListConfigs(admin *sarama.ClusterAdmin, resource sarama.ConfigResource) ([]Config, error) {
+func ListConfigs(admin *sarama.ClusterAdmin, resource sarama.ConfigResource, includeDefaults bool) ([]Config, error) {
 
 	var (
-		configs       = make([]Config, 0)
 		configEntries []sarama.ConfigEntry
 		err           error
 	)
@@ -321,15 +320,19 @@ func ListConfigs(admin *sarama.ClusterAdmin, resource sarama.ConfigResource) ([]
 		return nil, errors.Wrap(err, fmt.Sprintf("failed to describe %v config", getResourceTypeName(resource.Type)))
 	}
 
+	return listConfigsFromEntries(configEntries, includeDefaults), nil
+}
+
+func listConfigsFromEntries(configEntries []sarama.ConfigEntry, includeDefaults bool) (configs []Config) {
 	for _, configEntry := range configEntries {
 
-		if !configEntry.Default && configEntry.Source != sarama.SourceDefault {
+		if includeDefaults || (!configEntry.Default && configEntry.Source != sarama.SourceDefault) {
 			entry := Config{Name: configEntry.Name, Value: configEntry.Value}
 			configs = append(configs, entry)
 		}
 	}
 
-	return configs, nil
+	return
 }
 
 func getResourceTypeName(resourceType sarama.ConfigResourceType) string {

--- a/internal/common-operation_test.go
+++ b/internal/common-operation_test.go
@@ -1,0 +1,83 @@
+package internal
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/IBM/sarama"
+)
+
+func TestListConfigsFromEntries(t *testing.T) {
+	testCases := []struct {
+		name            string
+		entries         []sarama.ConfigEntry
+		includeDefaults bool
+		configs         []Config
+	}{
+		{
+			name:    "not include defaults, empty entries",
+			entries: []sarama.ConfigEntry{},
+			configs: []Config{},
+		},
+		{
+			name: "not include defaults",
+			entries: []sarama.ConfigEntry{
+				{
+					Name:    "non_default",
+					Value:   "ND",
+					Default: false,
+					Source:  sarama.SourceUnknown,
+				},
+				{
+					Name:    "default",
+					Value:   "D",
+					Default: true,
+					Source:  sarama.SourceDefault,
+				},
+			},
+			configs: []Config{
+				{Name: "non_default", Value: "ND"},
+			},
+		},
+		{
+			name:            "include defaults, empty entries",
+			entries:         []sarama.ConfigEntry{},
+			configs:         []Config{},
+			includeDefaults: true,
+		},
+		{
+			name: "include defaults",
+			entries: []sarama.ConfigEntry{
+				{
+					Name:    "non_default",
+					Value:   "ND",
+					Default: false,
+					Source:  sarama.SourceUnknown,
+				},
+				{
+					Name:    "default",
+					Value:   "D",
+					Default: true,
+					Source:  sarama.SourceDefault,
+				},
+			},
+			configs: []Config{
+				{Name: "non_default", Value: "ND"},
+				{Name: "default", Value: "D"},
+			},
+			includeDefaults: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			configs := listConfigsFromEntries(tc.entries, tc.includeDefaults)
+
+			if len(configs) > 0 &&
+				len(tc.configs) > 0 &&
+				!reflect.DeepEqual(configs, tc.configs) {
+				t.Fatalf("expect: %v, got %v", tc.configs, configs)
+			}
+		})
+	}
+}

--- a/internal/topic/topic-operation.go
+++ b/internal/topic/topic-operation.go
@@ -32,16 +32,18 @@ type Partition struct {
 }
 
 type requestedTopicFields struct {
-	partitionID           bool
-	partitionOffset       bool
-	partitionLeader       bool
-	partitionReplicas     bool
-	partitionISRs         bool
-	config                bool
-	configIncludeDefaults bool
+	partitionID       bool
+	partitionOffset   bool
+	partitionLeader   bool
+	partitionReplicas bool
+	partitionISRs     bool
+	config            PrintConfigsParam
 }
 
-var allFields = requestedTopicFields{partitionID: true, partitionOffset: true, partitionLeader: true, partitionReplicas: true, partitionISRs: true, config: true}
+var allFields = requestedTopicFields{
+	partitionID: true, partitionOffset: true, partitionLeader: true,
+	partitionReplicas: true, partitionISRs: true, config: NonDefaultConfigs,
+}
 
 type GetTopicsFlags struct {
 	OutputFormat string
@@ -61,11 +63,18 @@ type AlterTopicFlags struct {
 	Configs           []string
 }
 
+type PrintConfigsParam string
+
+const (
+	NoConfigs         PrintConfigsParam = "none"
+	AllConfigs        PrintConfigsParam = "all"
+	NonDefaultConfigs PrintConfigsParam = "no_defaults"
+)
+
 type DescribeTopicFlags struct {
-	PrintConfigs        bool
+	PrintConfigs        PrintConfigsParam
 	SkipEmptyPartitions bool
 	OutputFormat        string
-	IncludeDefaults     bool
 }
 
 type Operation struct {
@@ -164,7 +173,7 @@ func (operation *Operation) DescribeTopic(topic string, flags DescribeTopicFlags
 	}
 
 	fields := allFields
-	fields.configIncludeDefaults = flags.IncludeDefaults
+	fields.config = flags.PrintConfigs
 
 	if t, err = readTopic(&client, &admin, topic, fields); err != nil {
 		return errors.Wrap(err, "failed to read topic")
@@ -175,7 +184,7 @@ func (operation *Operation) DescribeTopic(topic string, flags DescribeTopicFlags
 
 func (operation *Operation) printTopic(topic Topic, flags DescribeTopicFlags) error {
 
-	if !flags.PrintConfigs {
+	if flags.PrintConfigs == NoConfigs {
 		topic.Configs = nil
 	}
 
@@ -406,7 +415,11 @@ func (operation *Operation) AlterTopic(topic string, flags AlterTopicFlags) erro
 	}
 
 	if flags.ValidateOnly {
-		describeFlags := DescribeTopicFlags{PrintConfigs: len(flags.Configs) > 0}
+		printConfigs := NoConfigs
+		if len(flags.Configs) > 0 {
+			printConfigs = NonDefaultConfigs
+		}
+		describeFlags := DescribeTopicFlags{PrintConfigs: printConfigs}
 		return operation.printTopic(t, describeFlags)
 	}
 	return nil
@@ -477,7 +490,7 @@ func (operation *Operation) CloneTopic(sourceTopic, targetTopic string) error {
 	requestedFields := requestedTopicFields{
 		partitionID:       true,
 		partitionReplicas: true,
-		config:            true,
+		config:            NonDefaultConfigs,
 	}
 
 	if t, err = readTopic(&client, &admin, sourceTopic, requestedFields); err != nil {
@@ -586,7 +599,7 @@ func (operation *Operation) GetTopics(flags GetTopicsFlags) error {
 	} else if flags.OutputFormat == "compact" {
 		tableWriter.Initialize()
 	} else if flags.OutputFormat == "wide" {
-		requestedFields = requestedTopicFields{partitionID: true, partitionReplicas: true, config: true}
+		requestedFields = requestedTopicFields{partitionID: true, partitionReplicas: true, config: NonDefaultConfigs}
 		if err := tableWriter.WriteHeader("TOPIC", "PARTITIONS", "REPLICATION FACTOR", "CONFIGS"); err != nil {
 			return err
 		}
@@ -730,14 +743,14 @@ func readTopic(client *sarama.Client, admin *sarama.ClusterAdmin, name string, r
 		return top.Partitions[i].ID < top.Partitions[j].ID
 	})
 
-	if requestedFields.config {
+	if requestedFields.config != NoConfigs {
 
 		topicConfig := sarama.ConfigResource{
 			Type: sarama.TopicResource,
 			Name: name,
 		}
 
-		if top.Configs, err = internal.ListConfigs(admin, topicConfig, requestedFields.configIncludeDefaults); err != nil {
+		if top.Configs, err = internal.ListConfigs(admin, topicConfig, requestedFields.config == AllConfigs); err != nil {
 			return top, err
 		}
 	}


### PR DESCRIPTION
# Description

Add `--include-defaults` flag when describing topics

```
kafkactl@sk-run-pod:~$ kafkactl describe topic topic-1 --output wide --include-defaults
```
I haven't done any integration test, but unit test run fine:
```
➜  kafkactl git:(177-describe-default-config) ✗ make test
fatal: No names found, cannot describe anything.
rm -f test.log
go test -v -short ./...
?   	github.com/deviceinsight/kafkactl	[no test files]
=== RUN   TestEnvironmentVariableLoading
--- PASS: TestEnvironmentVariableLoading (0.00s)

...

ok  	github.com/deviceinsight/kafkactl/util	(cached)
```

Fixes #177 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [ ] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.md` was updated
- [ ] a usage example was added to `README.md`
- [X] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
