### PR TITLE
Fix null pointer exception in sigterm

### DIFF
--- a/internal/consume/GroupConsumer.go
+++ b/internal/consume/GroupConsumer.go
@@ -96,10 +96,13 @@ func (handler *groupHandler) ConsumeClaim(session sarama.ConsumerGroupSession, c
 
 	for {
 		select {
-		case message := <-messageChannel:
-			if message != nil {
-				handler.messages <- message
+		case message, ok := <-messageChannel:
+			if !ok {
+				output.Debugf("consume claim via channel interrupted")
+				handler.cancel()
+				return nil
 			}
+			handler.messages <- message
 			session.MarkMessage(message, "")
 		case <-handler.stopConsumers:
 			output.Debugf("stop consume claim via channel")


### PR DESCRIPTION
# Description

Right now if you try to consume some messages as a part of a group consumer and then decide to <Ctrl-C> the app you will get an NPE

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)




