### PR TITLE
docs(README): wrong command name

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -822,7 +822,7 @@ The assigned replicas of a partition can directly be altered with:
 [,bash]
 ----
 # set brokers 102,103 as replicas for partition 3 of topic my-topic
-kafkactl alter topic my-topic 3 -r 102,103
+kafkactl alter partition my-topic 3 -r 102,103
 ----
 
 === Clone topic


### PR DESCRIPTION
# Description

Hello,

Only wrong command name, nothing fancy

## Type of change

Please delete options that are not relevant.

- [x] Documentation

## Documentation

- [ ] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [x] the configuration yaml was changed and the example config in `README.adoc` was updated
- [x] a usage example was added to `README.adoc`
- [ ] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
