### PR TITLE
add support for ALL_PROXY env var

### DIFF
--- a/internal/common-operation.go
+++ b/internal/common-operation.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/net/proxy"
+
 	"github.com/deviceinsight/kafkactl/v5/internal/auth"
 
 	"github.com/deviceinsight/kafkactl/v5/internal/global"
@@ -236,6 +238,11 @@ func CreateClientConfig(context *ClientContext) (*sarama.Config, error) {
 			return nil, errors.Wrap(err, "failed to load tokenProvider")
 		}
 		config.Net.SASL.TokenProvider = tokenProvider
+	}
+
+	if _proxy := os.Getenv("ALL_PROXY"); _proxy != "" {
+		config.Net.Proxy.Enable = true
+		config.Net.Proxy.Dialer = proxy.FromEnvironment()
 	}
 
 	return config, nil


### PR DESCRIPTION
# Description

There is situation where kafka cluster were behind Bastion SSH, where we won't be able to reach the nodes directly. This PR will add SOCKS proxy support via `ALL_PROXY` environment variable. 

```
ALL_PROXY=socks5://127.0.0.1:1080 kafkactl ...
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

