### PR TITLE
Add pod override fields affinity and tolerations 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [#203](https://github.com/deviceinsight/kafkactl/pull/203) Add pod override fields affinity and tolerations
 
 ## 5.2.0 - 2024-08-08
 

--- a/README.adoc
+++ b/README.adoc
@@ -144,6 +144,10 @@ contexts:
       # optional: nodeSelector to add to the pod
       nodeSelector:
         key: value
+      # optional: affinity to add to the pod
+      affnity: '{"nodeAffinity": "requiredDuringSchedulingIgnoredDuringExecution": {nodeSelectorTerms: [{"matchExpressions":[{"key":"<key>", "operator":"<operator>", "values":["<value>"]}]}]}}'
+      # optional: tolerations to add to the pod
+      tolerations: '[{"effect":"<effect>","key":"<key>","operator":"<operator>","value":"<value>"}]'
     # optional: clientID config (defaults to kafkactl-{username})
     clientID: my-client-id
 

--- a/README.adoc
+++ b/README.adoc
@@ -144,10 +144,25 @@ contexts:
       # optional: nodeSelector to add to the pod
       nodeSelector:
         key: value
+
       # optional: affinity to add to the pod
-      affnity: '{"nodeAffinity": "requiredDuringSchedulingIgnoredDuringExecution": {nodeSelectorTerms: [{"matchExpressions":[{"key":"<key>", "operator":"<operator>", "values":["<value>"]}]}]}}'
+      affinity:
+        # note: other types of affinity also supported
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: "<key>"
+                    operator: "<operator>"
+                    values: [ "<value>" ]
+
       # optional: tolerations to add to the pod
-      tolerations: '[{"effect":"<effect>","key":"<key>","operator":"<operator>","value":"<value>"}]'
+      tolerations:
+        - key: "<key>"
+          operator: "<operator>"
+          value: "<value>"
+          effect: "<effect>"
+
     # optional: clientID config (defaults to kafkactl-{username})
     clientID: my-client-id
 
@@ -628,7 +643,7 @@ Producing protobuf message converted from JSON:
 kafkactl produce my-topic --key='{"keyField":123}' --key-proto-type MyKeyMessage --value='{"valueField":"value"}' --value-proto-type MyValueMessage --proto-file kafkamsg.proto
 ----
 
-A more complex protobuf message converted from a multi-line JSON string can be produced using a file input with custom separators. 
+A more complex protobuf message converted from a multi-line JSON string can be produced using a file input with custom separators.
 
 For example, if you have the following protobuf definition (`complex.proto`):
 

--- a/internal/common-operation.go
+++ b/internal/common-operation.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -74,6 +75,8 @@ type K8sConfig struct {
 	Labels          map[string]string
 	Annotations     map[string]string
 	NodeSelector    map[string]string
+	Affinity        map[string]any
+	Tolerations     []map[string]any
 }
 
 type ConsumerConfig struct {
@@ -174,6 +177,14 @@ func CreateClientContext() (ClientContext, error) {
 	context.Kubernetes.Labels = viper.GetStringMapString("contexts." + context.Name + ".kubernetes.labels")
 	context.Kubernetes.Annotations = viper.GetStringMapString("contexts." + context.Name + ".kubernetes.annotations")
 	context.Kubernetes.NodeSelector = viper.GetStringMapString("contexts." + context.Name + ".kubernetes.nodeSelector")
+	context.Kubernetes.Affinity = viper.GetStringMap("contexts." + context.Name + ".kubernetes.affinity")
+
+	var tolerations []map[string]any
+	err := json.Unmarshal([]byte(viper.GetString("contexts."+context.Name+".kubernetes.tolerations")), &tolerations)
+	if err != nil {
+		return context, err
+	}
+	context.Kubernetes.Tolerations = tolerations
 
 	return context, nil
 }

--- a/internal/common-operation.go
+++ b/internal/common-operation.go
@@ -178,16 +178,28 @@ func CreateClientContext() (ClientContext, error) {
 	context.Kubernetes.Annotations = viper.GetStringMapString("contexts." + context.Name + ".kubernetes.annotations")
 	context.Kubernetes.NodeSelector = viper.GetStringMapString("contexts." + context.Name + ".kubernetes.nodeSelector")
 	context.Kubernetes.Affinity = viper.GetStringMap("contexts." + context.Name + ".kubernetes.affinity")
-
-	var tolerations []map[string]any
-	err := json.Unmarshal([]byte(viper.GetString("contexts."+context.Name+".kubernetes.tolerations")), &tolerations)
-	if err != nil {
-		return context, err
-	}
-	context.Kubernetes.Tolerations = tolerations
-
+  
+  t, err := convertJsonToListMap("tolerations", viper.GetString("contexts."+context.Name+".kubernetes.tolerations"))
+  context.Kubernetes.Tolerations = t
+  if err != nil {
+    return context, err 
+  } 
 	return context, nil
 }
+
+func convertJsonToListMap(fieldName string, jsonStr string) ([]map[string]any, error){
+  var listMap []map[string]any
+  if (jsonStr == "") {
+    return listMap, nil
+  }
+  err := json.Unmarshal([]byte(jsonStr), &listMap)
+  if err != nil {
+    fmt.Errorf("Error parsing %s field", fieldName)
+    return listMap, err
+  }
+  return listMap, nil 
+} 
+
 
 func CreateClient(context *ClientContext) (sarama.Client, error) {
 	config, err := CreateClientConfig(context)

--- a/internal/consumergroupoffsets/consumer-group-offset-operation.go
+++ b/internal/consumergroupoffsets/consumer-group-offset-operation.go
@@ -29,7 +29,7 @@ type ConsumerGroupOffsetOperation struct {
 
 func (operation *ConsumerGroupOffsetOperation) ResetConsumerGroupOffset(flags ResetConsumerGroupOffsetFlags, groupName string) error {
 
-	if (flags.Topic == nil || len(flags.Topic) == 0) && (!flags.AllTopics) {
+	if (len(flags.Topic) == 0) && (!flags.AllTopics) {
 		return errors.New("no topic specified")
 	}
 

--- a/internal/k8s/executor.go
+++ b/internal/k8s/executor.go
@@ -37,6 +37,8 @@ type executor struct {
 	labels          map[string]string
 	annotations     map[string]string
 	nodeSelector    map[string]string
+	affinity        map[string]any
+	tolerations     []map[string]any
 }
 
 const letterBytes = "abcdefghijklmnpqrstuvwxyz123456789"
@@ -111,6 +113,8 @@ func newExecutor(context internal.ClientContext, runner Runner) *executor {
 		labels:          context.Kubernetes.Labels,
 		annotations:     context.Kubernetes.Annotations,
 		nodeSelector:    context.Kubernetes.NodeSelector,
+		affinity:        context.Kubernetes.Affinity,
+		tolerations:     context.Kubernetes.Tolerations,
 		runner:          runner,
 	}
 }

--- a/internal/k8s/executor.go
+++ b/internal/k8s/executor.go
@@ -38,7 +38,7 @@ type executor struct {
 	annotations     map[string]string
 	nodeSelector    map[string]string
 	affinity        map[string]any
-	tolerations     []map[string]any
+	tolerations     []internal.K8sToleration
 }
 
 const letterBytes = "abcdefghijklmnpqrstuvwxyz123456789"

--- a/internal/k8s/pod_overrides.go
+++ b/internal/k8s/pod_overrides.go
@@ -13,6 +13,8 @@ type specType struct {
 	ImagePullSecrets   []imagePullSecretType `json:"imagePullSecrets,omitempty"`
 	ServiceAccountName *string               `json:"serviceAccountName,omitempty"`
 	NodeSelector       *map[string]string    `json:"nodeSelector,omitempty"`
+	Affinity           *map[string]any       `json:"affinity,omitempty"`
+	Tolerations        *[]map[string]any     `json:"tolerations,omitempty"`
 }
 
 type PodOverrideType struct {
@@ -29,7 +31,7 @@ func (kubectl *executor) createPodOverride() PodOverrideType {
 	var override PodOverrideType
 	override.APIVersion = "v1"
 
-	if kubectl.serviceAccount != "" || kubectl.imagePullSecret != "" || len(kubectl.nodeSelector) > 0 {
+	if kubectl.serviceAccount != "" || kubectl.imagePullSecret != "" || len(kubectl.nodeSelector) > 0 || len(kubectl.affinity) > 0 || len(kubectl.tolerations) > 0 {
 		override.Spec = &specType{}
 
 		if kubectl.serviceAccount != "" {
@@ -43,6 +45,14 @@ func (kubectl *executor) createPodOverride() PodOverrideType {
 
 		if len(kubectl.nodeSelector) > 0 {
 			override.Spec.NodeSelector = &kubectl.nodeSelector
+		}
+
+		if len(kubectl.affinity) > 0 {
+			override.Spec.Affinity = &kubectl.affinity
+		}
+
+		if len(kubectl.tolerations) > 0 {
+			override.Spec.Tolerations = &kubectl.tolerations
 		}
 	}
 

--- a/internal/k8s/pod_overrides.go
+++ b/internal/k8s/pod_overrides.go
@@ -1,5 +1,7 @@
 package k8s
 
+import "github.com/deviceinsight/kafkactl/v5/internal"
+
 type imagePullSecretType struct {
 	Name string `json:"name"`
 }
@@ -10,11 +12,11 @@ type metadataType struct {
 }
 
 type specType struct {
-	ImagePullSecrets   []imagePullSecretType `json:"imagePullSecrets,omitempty"`
-	ServiceAccountName *string               `json:"serviceAccountName,omitempty"`
-	NodeSelector       *map[string]string    `json:"nodeSelector,omitempty"`
-	Affinity           *map[string]any       `json:"affinity,omitempty"`
-	Tolerations        *[]map[string]any     `json:"tolerations,omitempty"`
+	ImagePullSecrets   []imagePullSecretType     `json:"imagePullSecrets,omitempty"`
+	ServiceAccountName *string                   `json:"serviceAccountName,omitempty"`
+	NodeSelector       *map[string]string        `json:"nodeSelector,omitempty"`
+	Affinity           *map[string]any           `json:"affinity,omitempty"`
+	Tolerations        *[]internal.K8sToleration `json:"tolerations,omitempty"`
 }
 
 type PodOverrideType struct {

--- a/internal/producer/producer-operation.go
+++ b/internal/producer/producer-operation.go
@@ -213,7 +213,7 @@ func (operation *Operation) Produce(topic string, flags Flags) error {
 			}
 
 			if inputMessage, err = inputParser.ParseLine(line); err != nil {
-				return failWithMessageCount(messageCount, err.Error())
+				return failWithMessageCount(messageCount, err.Error()) //nolint:govet
 			}
 
 			messageCount++


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.
List any dependencies that are required for this change.

Fixes # (issue)
This PR adds the pod overrides affinity and tolerations, unfortunately nodeSelector field is not enough for all use cases. 
The changes in this PR include:
- Addition of affinity field for spec type pod overrides
- Additions of tolerations field for spec type pod overrides


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [x] the configuration yaml was changed and the example config in `README.adoc` was updated
- [x] a usage example was added to `README.adoc`
- [x] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
