### PR TITLE
allow configuring ssl for avro schema registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,25 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## 5.0.6 - 2024-03-14
+### Changed
+- Updated several dependencies and replaced abandoned avro schema registry lib with a new library
+
+### Added
+- [#207](https://github.com/deviceinsight/kafkactl/pull/207) Allow configuring TLS for avro schema registry
 
 ## 5.0.6 - 2024-03-14
-
-## 5.0.6 - 2024-03-14
-
-## 5.0.6 - 2024-03-14
-
-## 5.0.5 - 2024-03-12
-
-## 5.0.4 - 2024-03-12
-
-## 5.0.3 - 2024-03-12
-
-## 5.0.2 - 2024-03-08
-
-## 5.0.1 - 2024-03-08
-
-## 5.0.0 - 2024-03-08
 
 ### Added
 - [#190](https://github.com/deviceinsight/kafkactl/pull/190) Improve handling of project config files

--- a/README.adoc
+++ b/README.adoc
@@ -160,6 +160,18 @@ contexts:
       # see: https://github.com/deviceinsight/kafkactl/issues/123
       jsonCodec: avro
 
+      # optional: timeout for requests (defaults to 5s)
+      requestTimeout: 10s
+
+      # optional: tls config for avro
+      tls:
+        enabled: true
+        ca: my-ca
+        cert: my-cert
+        certKey: my-key
+        # set insecure to true to ignore all tls verification (defaults to false)
+        insecure: false
+
     # optional: default protobuf messages search paths
     protobuf:
       importPaths:

--- a/internal/consume/AvroMessageDeserializer.go
+++ b/internal/consume/AvroMessageDeserializer.go
@@ -16,25 +16,9 @@ import (
 )
 
 type AvroMessageDeserializer struct {
-	topic              string
-	avroSchemaRegistry string
-	jsonCodec          avro.JSONCodec
-	registry           *CachingSchemaRegistry
-}
-
-func CreateAvroMessageDeserializer(topic string, avroSchemaRegistry string, jsonCodec avro.JSONCodec) (AvroMessageDeserializer, error) {
-
-	var err error
-
-	deserializer := AvroMessageDeserializer{topic: topic, avroSchemaRegistry: avroSchemaRegistry, jsonCodec: jsonCodec}
-
-	deserializer.registry, err = CreateCachingSchemaRegistry(deserializer.avroSchemaRegistry)
-
-	if err != nil {
-		return deserializer, errors.Wrap(err, "failed to create schema registry client: ")
-	}
-
-	return deserializer, nil
+	topic     string
+	jsonCodec avro.JSONCodec
+	registry  *CachingSchemaRegistry
 }
 
 type avroMessage struct {

--- a/internal/consume/CachingSchemaRegistry.go
+++ b/internal/consume/CachingSchemaRegistry.go
@@ -1,7 +1,6 @@
 package consume
 
 import (
-	"github.com/deviceinsight/kafkactl/v5/internal/helpers/avro"
 	"github.com/riferrei/srclient"
 )
 
@@ -11,14 +10,8 @@ type CachingSchemaRegistry struct {
 	client   srclient.ISchemaRegistryClient
 }
 
-func CreateCachingSchemaRegistry(avroSchemaRegistry string) (*CachingSchemaRegistry, error) {
-
-	registry := &CachingSchemaRegistry{}
-
-	registry.schemas = make(map[int]string)
-	registry.client = avro.CreateSchemaRegistryClient(avroSchemaRegistry)
-
-	return registry, nil
+func CreateCachingSchemaRegistry(client srclient.ISchemaRegistryClient) *CachingSchemaRegistry {
+	return &CachingSchemaRegistry{client: client, schemas: make(map[int]string)}
 }
 
 func (registry *CachingSchemaRegistry) Subjects() ([]string, error) {

--- a/internal/consume/consume-operation.go
+++ b/internal/consume/consume-operation.go
@@ -91,10 +91,13 @@ func (operation *Operation) Consume(topic string, flags Flags) error {
 	var deserializers MessageDeserializerChain
 
 	if clientContext.AvroSchemaRegistry != "" {
-		deserializer, err := CreateAvroMessageDeserializer(topic, clientContext.AvroSchemaRegistry, clientContext.AvroJSONCodec)
+		client, err := internal.CreateAvroSchemaRegistryClient(&clientContext)
 		if err != nil {
 			return err
 		}
+
+		deserializer := AvroMessageDeserializer{topic: topic, registry: CreateCachingSchemaRegistry(client),
+			jsonCodec: clientContext.AvroJSONCodec}
 
 		deserializers = append(deserializers, deserializer)
 	}

--- a/internal/helpers/avro/SchemaRegistry.go
+++ b/internal/helpers/avro/SchemaRegistry.go
@@ -2,17 +2,10 @@ package avro
 
 import (
 	"strings"
-
-	"github.com/riferrei/srclient"
 )
 
-func CreateSchemaRegistryClient(baseURL string) srclient.ISchemaRegistryClient {
-	baseURL = formatBaseURL(baseURL)
-	return srclient.CreateSchemaRegistryClient(baseURL)
-}
-
-// formatBaseURL will try to make sure that the schema:host:port pattern is followed on the `baseURL` field.
-func formatBaseURL(baseURL string) string {
+// FormatBaseURL will try to make sure that the schema:host:port pattern is followed on the `baseURL` field.
+func FormatBaseURL(baseURL string) string {
 	if baseURL == "" {
 		return ""
 	}

--- a/internal/producer/AvroMessageSerializer.go
+++ b/internal/producer/AvroMessageSerializer.go
@@ -13,19 +13,9 @@ import (
 )
 
 type AvroMessageSerializer struct {
-	topic              string
-	avroSchemaRegistry string
-	jsonCodec          avro.JSONCodec
-	client             srclient.ISchemaRegistryClient
-}
-
-func CreateAvroMessageSerializer(topic string, avroSchemaRegistry string, jsonCodec avro.JSONCodec) (AvroMessageSerializer, error) {
-
-	serializer := AvroMessageSerializer{topic: topic, avroSchemaRegistry: avroSchemaRegistry, jsonCodec: jsonCodec}
-
-	serializer.client = avro.CreateSchemaRegistryClient(serializer.avroSchemaRegistry)
-
-	return serializer, nil
+	topic     string
+	jsonCodec avro.JSONCodec
+	client    srclient.ISchemaRegistryClient
 }
 
 func (serializer AvroMessageSerializer) encode(rawData []byte, schemaVersion int, avroSchemaType string) ([]byte, error) {

--- a/internal/producer/producer-operation.go
+++ b/internal/producer/producer-operation.go
@@ -80,10 +80,11 @@ func (operation *Operation) Produce(topic string, flags Flags) error {
 	serializers := MessageSerializerChain{topic: topic}
 
 	if clientContext.AvroSchemaRegistry != "" {
-		serializer, err := CreateAvroMessageSerializer(topic, clientContext.AvroSchemaRegistry, clientContext.AvroJSONCodec)
+		client, err := internal.CreateAvroSchemaRegistryClient(&clientContext)
 		if err != nil {
 			return err
 		}
+		serializer := AvroMessageSerializer{topic: topic, client: client, jsonCodec: clientContext.AvroJSONCodec}
 
 		serializers.serializers = append(serializers.serializers, serializer)
 	}


### PR DESCRIPTION
# Description

This fix allows configuring SSL for avro in detail.

Fixes #204

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [x] the configuration yaml was changed and the example config in `README.adoc` was updated

