### PR TITLE
Allow creating topic using topic description from file

### DIFF
--- a/cmd/create/create-topic.go
+++ b/cmd/create/create-topic.go
@@ -27,6 +27,7 @@ func newCreateTopicCmd() *cobra.Command {
 	cmdCreateTopic.Flags().Int32VarP(&flags.Partitions, "partitions", "p", 1, "number of partitions")
 	cmdCreateTopic.Flags().Int16VarP(&flags.ReplicationFactor, "replication-factor", "r", -1, "replication factor")
 	cmdCreateTopic.Flags().BoolVarP(&flags.ValidateOnly, "validate-only", "v", false, "validate only")
+	cmdCreateTopic.Flags().StringVarP(&flags.File, "file", "f", "", "file with topic description")
 	cmdCreateTopic.Flags().StringArrayVarP(&flags.Configs, "config", "c", flags.Configs, "configs in format `key=value`")
 
 	return cmdCreateTopic

--- a/cmd/create/create-topic_test.go
+++ b/cmd/create/create-topic_test.go
@@ -2,6 +2,7 @@ package create_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -105,6 +106,101 @@ partitions:
   leader: any-broker
   replicas: [any-broker-id, any-broker-id, any-broker-id]
   inSyncReplicas: [any-broker-id, any-broker-id, any-broker-id]`
+
+	testutil.AssertEquals(t, fmt.Sprintf(expected, topicName), stdOut)
+}
+
+func TestCreateTopicWithConfigFileIntegration(t *testing.T) {
+
+	testutil.StartIntegrationTest(t)
+
+	kafkaCtl := testutil.CreateKafkaCtlCommand()
+
+	topicName := testutil.GetPrefixedName("new-topic")
+	configFile := fmt.Sprintf(`
+name: %s
+partitions:
+- id: 0
+  oldestOffset: 0
+  newestOffset: 290
+  leader: kafka:9092
+  replicas: [1]
+  inSyncReplicas: [1]
+- id: 1
+  oldestOffset: 0
+  newestOffset: 258
+  leader: kafka:9092
+  replicas: [1]
+  inSyncReplicas: [1]
+- id: 2
+  oldestOffset: 0
+  newestOffset: 290
+  leader: kafka:9092
+  replicas: [1]
+  inSyncReplicas: [1]
+configs:
+- name: cleanup.policy
+  value: compact
+- name: max.message.bytes
+  value: "10485880"
+- name: min.cleanable.dirty.ratio
+  value: "1.0E-4"
+- name: delete.retention.ms
+  value: "0"
+- name: segment.ms
+  value: "100"
+`, topicName)
+
+	tmpFile, err := os.CreateTemp("", fmt.Sprintf("%s-*.yaml", topicName))
+	if err != nil {
+		t.Fatalf("could not create temp file with topic config: %s", err)
+	}
+	defer tmpFile.Close()
+	if _, err := tmpFile.WriteString(configFile); err != nil {
+		t.Fatalf("could not write temp config file: %s", err)
+	}
+
+	if _, err := kafkaCtl.Execute("create", "topic", topicName, "-f", tmpFile.Name()); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	testutil.AssertEquals(t, fmt.Sprintf("topic created: %s", topicName), kafkaCtl.GetStdOut())
+
+	describeTopic(t, kafkaCtl, topicName)
+	stdOut := testutil.WithoutBrokerReferences(kafkaCtl.GetStdOut())
+
+	expected := `
+name: %s
+partitions:
+- id: 0
+  oldestOffset: 0
+  newestOffset: 0
+  leader: any-broker
+  replicas: [any-broker-id]
+  inSyncReplicas: [any-broker-id]
+- id: 1
+  oldestOffset: 0
+  newestOffset: 0
+  leader: any-broker
+  replicas: [any-broker-id]
+  inSyncReplicas: [any-broker-id]
+- id: 2
+  oldestOffset: 0
+  newestOffset: 0
+  leader: any-broker
+  replicas: [any-broker-id]
+  inSyncReplicas: [any-broker-id]
+configs:
+- name: cleanup.policy
+  value: compact
+- name: max.message.bytes
+  value: "10485880"
+- name: min.cleanable.dirty.ratio
+  value: "1.0E-4"
+- name: delete.retention.ms
+  value: "0"
+- name: segment.ms
+  value: "100"`
 
 	testutil.AssertEquals(t, fmt.Sprintf(expected, topicName), stdOut)
 }


### PR DESCRIPTION
# Description
Allow the creation of a topic using configuration description from file
```sh
kafkactl describe topic my-topic -o json > my-topic-config.json
kafkactl create topic my-topic-clone --file my-topic-config.json
```

Note that in the current implementation configuration from file would override the configuration provided via flag.
For example, if the file specifies that the topic has 10 partitions even if `--partition=5` flag is set, 10 partitions will be created. 
This might be confusing for the user. 

I could have implemented the reading of the config file to happen in `cmd/create/create-topic.go` so the flags can override the configuration from the file, but it looked that it would be a bigger change in the project structure.  
I am happy to change it so flags override config file values if you think this is a better approach. 

We can also return an error if some flags and `--file` flag are provided together, so it wont allow the user to  provide `--partition` and `--file` simultaneously. 
But then we have the same problem with `--config` and `--file`, unless we want to forbid the user to provide `--config` flag (which will unnecessarily limit the functionality), we should establish order of precedence - flag over file or vice versa. 

Related to issue  #202 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [ ] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.adoc` was updated
- [ ] a usage example was added to `README.adoc`
- [x] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
