### PR TITLE
Add `aws` plugin in README supported plugins list

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -384,6 +384,7 @@ See the plugin documentation for additional documentation and usage examples.
 
 Available plugins:
 
+* https://github.com/deviceinsight/kafkactl-plugins/blob/main/aws/README.adoc[aws plugin]
 * https://github.com/deviceinsight/kafkactl-plugins/blob/main/azure/README.adoc[azure plugin]
 
 == Examples


### PR DESCRIPTION
# Description

Add `aws` plugin.

`aws` plugin has been released [v1.1.0, deviceinsight/kafkactl-plugins/](https://github.com/deviceinsight/kafkactl-plugins/releases/tag/v1.1.0) and now the AWS MSK users are ready for IAM access control with `kafkactl`.

Fixes https://github.com/deviceinsight/kafkactl/issues/152
Follow up of https://github.com/deviceinsight/kafkactl-plugins/pull/1

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [ ] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.adoc` was updated
- [ ] a usage example was added to `README.adoc`
- [ ] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
