### PR TITLE
Add --context flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [#214](https://github.com/deviceinsight/kafkactl/pull/214) Add `--context` option to set command's context
 
 ## 5.3.0 - 2024-08-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- [#214](https://github.com/deviceinsight/kafkactl/pull/214) Add `--context` option to set command's context
+- [#215](https://github.com/deviceinsight/kafkactl/pull/215) Add `--context` option to set command's context
 
 ## 5.3.0 - 2024-08-14
 ### Added

--- a/cmd/config/useContext.go
+++ b/cmd/config/useContext.go
@@ -1,10 +1,7 @@
 package config
 
 import (
-	"sort"
-
 	"github.com/deviceinsight/kafkactl/v5/internal/global"
-
 	"github.com/deviceinsight/kafkactl/v5/internal/output"
 	"github.com/pkg/errors"
 
@@ -42,15 +39,7 @@ func newUseContextCmd() *cobra.Command {
 				return nil, cobra.ShellCompDirectiveNoFileComp
 			}
 
-			contextMap := viper.GetStringMap("contexts")
-			contexts := make([]string, 0, len(contextMap))
-			for k := range contextMap {
-				contexts = append(contexts, k)
-			}
-
-			sort.Strings(contexts)
-
-			return contexts, cobra.ShellCompDirectiveNoFileComp
+			return global.ListAvailableContexts(), cobra.ShellCompDirectiveNoFileComp
 		},
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/spf13/viper"
+
 	"github.com/deviceinsight/kafkactl/v5/internal/global"
 
 	"github.com/deviceinsight/kafkactl/v5/cmd/alter"
@@ -54,6 +56,18 @@ func NewKafkactlCommand(streams output.IOStreams) *cobra.Command {
 	rootCmd.PersistentFlags().StringVarP(&globalFlags.ConfigFile, "config-file", "C", "",
 		fmt.Sprintf("config file. default locations: %v", globalConfig.DefaultPaths()))
 	rootCmd.PersistentFlags().BoolVarP(&globalFlags.Verbose, "verbose", "V", false, "verbose output")
+	rootCmd.PersistentFlags().StringVar(&globalFlags.Context, "context", "", "The name of the context to use")
+
+	err := rootCmd.RegisterFlagCompletionFunc("context", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		var contexts []string
+		for k := range viper.GetStringMap("contexts") {
+			contexts = append(contexts, k)
+		}
+		return contexts, cobra.ShellCompDirectiveDefault
+	})
+	if err != nil {
+		panic(err)
+	}
 
 	k8s.KafkaCtlVersion = Version
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/spf13/viper"
-
 	"github.com/deviceinsight/kafkactl/v5/internal/global"
 
 	"github.com/deviceinsight/kafkactl/v5/cmd/alter"
@@ -59,11 +57,7 @@ func NewKafkactlCommand(streams output.IOStreams) *cobra.Command {
 	rootCmd.PersistentFlags().StringVar(&globalFlags.Context, "context", "", "The name of the context to use")
 
 	err := rootCmd.RegisterFlagCompletionFunc("context", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-		var contexts []string
-		for k := range viper.GetStringMap("contexts") {
-			contexts = append(contexts, k)
-		}
-		return contexts, cobra.ShellCompDirectiveDefault
+		return global.ListAvailableContexts(), cobra.ShellCompDirectiveNoFileComp
 	})
 	if err != nil {
 		panic(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,7 +58,7 @@ func NewKafkactlCommand(streams output.IOStreams) *cobra.Command {
 	rootCmd.PersistentFlags().BoolVarP(&globalFlags.Verbose, "verbose", "V", false, "verbose output")
 	rootCmd.PersistentFlags().StringVar(&globalFlags.Context, "context", "", "The name of the context to use")
 
-	err := rootCmd.RegisterFlagCompletionFunc("context", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	err := rootCmd.RegisterFlagCompletionFunc("context", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		var contexts []string
 		for k := range viper.GetStringMap("contexts") {
 			contexts = append(contexts, k)

--- a/internal/global/config.go
+++ b/internal/global/config.go
@@ -64,10 +64,9 @@ func GetCurrentContext() string {
 		}
 
 		return context
-	} else {
-		return configInstance.currentContext()
 	}
 
+	return configInstance.currentContext()
 }
 
 func SetCurrentContext(contextName string) error {

--- a/internal/global/config.go
+++ b/internal/global/config.go
@@ -2,6 +2,7 @@ package global
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -13,6 +14,7 @@ import (
 
 type Flags struct {
 	ConfigFile string
+	Context    string
 	Verbose    bool
 }
 
@@ -52,7 +54,20 @@ func GetFlags() Flags {
 }
 
 func GetCurrentContext() string {
-	return configInstance.currentContext()
+	var context = configInstance.Flags().Context
+	if context != "" {
+		contexts := viper.GetStringMap("contexts")
+
+		// check if it is an existing context
+		if _, ok := contexts[context]; !ok {
+			output.Fail(fmt.Errorf("not a valid context: %s", context))
+		}
+
+		return context
+	} else {
+		return configInstance.currentContext()
+	}
+
 }
 
 func SetCurrentContext(contextName string) error {

--- a/internal/global/config.go
+++ b/internal/global/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 
 	"github.com/deviceinsight/kafkactl/v5/internal/output"
@@ -51,6 +52,17 @@ func NewConfig() Config {
 
 func GetFlags() Flags {
 	return configInstance.flags
+}
+
+func ListAvailableContexts() []string {
+
+	var contexts []string
+	for k := range viper.GetStringMap("contexts") {
+		contexts = append(contexts, k)
+	}
+
+	sort.Strings(contexts)
+	return contexts
 }
 
 func GetCurrentContext() string {


### PR DESCRIPTION
# Description

This patch adds an optional --context global flag.
Setting  `--context` overrides the current context to use for this command. 
Its behavior is similar to `kubectl --context`.

Fixes #214

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.adoc` was updated
- [ ] a usage example was added to `README.adoc`
- [ ] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
