### PR TITLE
fix: use schema id from avro for deser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [#230](https://github.com/deviceinsight/kafkactl/issues/230) Match schema of Avro messages by id
 
 ## 5.5.1 - 2025-03-05
 

--- a/internal/consume/AvroMessageDeserializer.go
+++ b/internal/consume/AvroMessageDeserializer.go
@@ -11,7 +11,6 @@ import (
 	"github.com/IBM/sarama"
 	"github.com/deviceinsight/kafkactl/v5/internal"
 	"github.com/deviceinsight/kafkactl/v5/internal/output"
-	"github.com/deviceinsight/kafkactl/v5/internal/util"
 	"github.com/linkedin/goavro/v2"
 	"github.com/pkg/errors"
 )
@@ -102,17 +101,6 @@ func (deserializer AvroMessageDeserializer) decode(rawData []byte, flags Flags, 
 
 	output.Debugf("decode %s and id %d", subject, schemaID)
 
-	subjects, err := deserializer.registry.Subjects()
-
-	if err != nil {
-		return decodedValue{}, errors.Wrap(err, "failed to list available avro schemas")
-	}
-
-	if !util.ContainsString(subjects, subject) {
-		// does not seem to be avro data
-		return decodedValue{value: encodeBytes(rawData, flags.EncodeValue)}, nil
-	}
-
 	schema, err := deserializer.registry.GetSchemaByID(schemaID)
 
 	if err != nil {
@@ -146,18 +134,9 @@ func (deserializer AvroMessageDeserializer) decode(rawData []byte, flags Flags, 
 }
 
 func (deserializer AvroMessageDeserializer) CanDeserialize(topic string) (bool, error) {
-	subjects, err := deserializer.registry.Subjects()
-
-	if err != nil {
-		return false, errors.Wrap(err, "failed to list available avro schemas")
-	}
-
-	if util.ContainsString(subjects, topic+"-key") {
-		return true, nil
-	} else if util.ContainsString(subjects, topic+"-value") {
-		return true, nil
-	}
-	return false, nil
+	/* no checks done here - checking whether deserialization is possible is done in
+	decode() where we actual data including schema id is available */
+	return true, nil
 }
 
 func (deserializer AvroMessageDeserializer) Deserialize(rawMsg *sarama.ConsumerMessage, flags Flags) error {


### PR DESCRIPTION
# Description

Match schema of Avro messages by id

Determine schema for AVRO deser based on schema id in the actual AVRO message instead of checking for schema matching the topic name.

Fixes #230 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [X] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.adoc` was updated
- [ ] a usage example was added to `README.adoc`
- [ ] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
