### PR TITLE
Build kafkactl on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,15 @@
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
 BUILD_TS := $(shell date -Iseconds --utc)
+OS ?= linux
+endif
+ifeq ($(UNAME_S),Darwin)
+BUILD_TS := $(shell TZ=Europe/London date -Iseconds)
+OS ?= darwin
+endif
+
 COMMIT_SHA := $(shell git rev-parse HEAD)
 VERSION := $(shell git describe --abbrev=0 --tags || echo "latest")
-OS ?= linux
 
 export CGO_ENABLED=0
 export GOOS=$(OS)


### PR DESCRIPTION
# Description

I'm building this on macOS. `date` works there differently and what's more important this change makes it possible to build
the binary for macOS to easily run it

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [ ] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.adoc` was updated
- [ ] a usage example was added to `README.adoc`
- [ ] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
