### PR TITLE
Use cache from the srclient library

### DIFF
--- a/internal/consume/AvroMessageDeserializer.go
+++ b/internal/consume/AvroMessageDeserializer.go
@@ -20,7 +20,7 @@ func (deserializer *AvroMessageDeserializer) canDeserialize(consumerMsg *sarama.
 
 	schemaID, err := deserializer.registry.ExtractSchemaID(data)
 	if err == nil {
-		schema, schemaErr := deserializer.registry.GetSchemaByID(schemaID)
+		schema, schemaErr := deserializer.registry.GetSchema(schemaID)
 		if schemaErr != nil {
 			output.Debugf("schema not found. id=%d partition=%d, offset=%d error=%v", schemaID,
 				consumerMsg.Partition, consumerMsg.Offset, err)
@@ -52,7 +52,7 @@ func (deserializer *AvroMessageDeserializer) deserialize(data []byte) (*Deserial
 		return nil, err
 	}
 
-	schema, err := deserializer.registry.GetSchemaByID(schemaID)
+	schema, err := deserializer.registry.GetSchema(schemaID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/producer/AvroMessageSerializer.go
+++ b/internal/producer/AvroMessageSerializer.go
@@ -23,8 +23,7 @@ func (serializer AvroMessageSerializer) encode(rawData []byte, schemaVersion int
 
 	subject := serializer.topic + "-" + avroSchemaType
 
-	subjects, err := serializer.client.Subjects()
-
+	subjects, err := serializer.client.GetSubjects()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list available avro schemas")
 	}
@@ -86,8 +85,7 @@ func (serializer AvroMessageSerializer) encode(rawData []byte, schemaVersion int
 
 func (serializer AvroMessageSerializer) CanSerialize(topic string) (bool, error) {
 
-	subjects, err := serializer.client.Subjects()
-
+	subjects, err := serializer.client.GetSubjects()
 	if err != nil {
 		return false, errors.Wrap(err, "failed to list available avro schemas")
 	}


### PR DESCRIPTION
# Description

CachingSchemaRegistry now uses internal cache from the srclient library. It means less code with exactly the same functionality. It also implements the `ISchemaRegistryClient` interface so every method of it can be used without the need of exposing it.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [ ] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.adoc` was updated
- [ ] a usage example was added to `README.adoc`
- [ ] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
