### PR TITLE
Add schema registry support for protobufs

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -68,6 +68,6 @@ jobs:
       - name: Upload logs
         uses: actions/upload-artifact@v4
         with:
-          name: it-logs
+          name: it-logs-${{ matrix.cp_version }}
           path: integration-test.log
           overwrite: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- #232 Protobufs serialization and deserialization now supports schemaRegistry
+- [#232](https://github.com/deviceinsight/kafkactl/pull/232) Protobufs serialization and deserialization now supports schemaRegistry
 
 ## 5.6.0 - 2025-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- #232 Protobufs serialization and deserialization now supports schemaRegistry
+
 ## 5.6.0 - 2025-03-11
 
 ### Changed

--- a/README.adoc
+++ b/README.adoc
@@ -690,8 +690,8 @@ In order to enable avro support you just have to add the schema registry to your
 ----
 contexts:
   localhost:
-    avro:
-      schemaRegistry: localhost:8081
+    schemaRegistry:
+      url: localhost:8081
 ----
 
 ==== Producing to an avro topic

--- a/cmd/consume/consume.go
+++ b/cmd/consume/consume.go
@@ -10,10 +10,9 @@ import (
 )
 
 func NewConsumeCmd() *cobra.Command {
-
 	var flags consume.Flags
 
-	var cmdConsume = &cobra.Command{
+	cmdConsume := &cobra.Command{
 		Use:   "consume TOPIC",
 		Short: "consume messages from a topic",
 		Args:  cobra.ExactArgs(1),
@@ -30,7 +29,7 @@ func NewConsumeCmd() *cobra.Command {
 	cmdConsume.Flags().BoolVarP(&flags.PrintPartitions, "print-partitions", "", false, "print message partitions")
 	cmdConsume.Flags().BoolVarP(&flags.PrintKeys, "print-keys", "k", false, "print message keys")
 	cmdConsume.Flags().BoolVarP(&flags.PrintTimestamps, "print-timestamps", "t", false, "print message timestamps")
-	cmdConsume.Flags().BoolVarP(&flags.PrintSchema, "print-schema", "a", false, "print details about avro schema used for decoding")
+	cmdConsume.Flags().BoolVarP(&flags.PrintSchema, "print-schema", "a", false, "print details about schema used for decoding")
 	cmdConsume.Flags().BoolVarP(&flags.PrintHeaders, "print-headers", "", false, "print message headers")
 	cmdConsume.Flags().IntVarP(&flags.Tail, "tail", "", -1, "show only the last n messages on the topic")
 	cmdConsume.Flags().StringVarP(&flags.FromTimestamp, "from-timestamp", "", "", "consume data from offset of given timestamp")

--- a/cmd/consume/consume_test.go
+++ b/cmd/consume/consume_test.go
@@ -92,7 +92,7 @@ func TestConsumeTailIntegration(t *testing.T) {
 	testutil.AssertEquals(t, "test-key-2#test-value-2b", messages[2])
 }
 
-func TestConsumeFromTimestamp(t *testing.T) {
+func TestConsumeFromTimestampIntegration(t *testing.T) {
 	testutil.StartIntegrationTest(t)
 
 	topicName := testutil.CreateTopic(t, "consume-topic", "--partitions", "2")
@@ -116,8 +116,8 @@ func TestConsumeFromTimestamp(t *testing.T) {
 
 	// test --from-timestamp with --to-timestamp with formatted dates
 	kafkaCtl := testutil.CreateKafkaCtlCommand()
-	t1Formatted := time.UnixMilli(t1).Format("2006-01-02T15:04:05.123Z")
-	t2Formatted := time.UnixMilli(t2).Format("2006-01-02T15:04:05.123Z")
+	t1Formatted := time.UnixMilli(t1).Format("2006-01-02T15:04:05.000Z")
+	t2Formatted := time.UnixMilli(t2).Format("2006-01-02T15:04:05.000Z")
 	if _, err := kafkaCtl.Execute("consume", topicName, "--from-timestamp", t1Formatted, "--to-timestamp", t2Formatted); err != nil {
 		t.Fatalf("failed to execute command: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestConsumeFromTimestamp(t *testing.T) {
 
 	// test --from-timestamp with --to-timestamp with unix epoch millis timestamps
 	kafkaCtl = testutil.CreateKafkaCtlCommand()
-	if _, err := kafkaCtl.Execute("consume", topicName, "--from-timestamp", strconv.FormatInt(t2, 10), "--to-timestamp", strconv.FormatInt(t2, 10)); err != nil {
+	if _, err := kafkaCtl.Execute("consume", topicName, "--from-timestamp", strconv.FormatInt(t1, 10), "--to-timestamp", strconv.FormatInt(t2, 10)); err != nil {
 		t.Fatalf("failed to execute command: %v", err)
 	}
 	messages = strings.Split(strings.TrimSpace(kafkaCtl.GetStdOut()), "\n")
@@ -149,7 +149,7 @@ func TestConsumeFromTimestamp(t *testing.T) {
 	testutil.AssertArraysEquals(t, []string{"g", "h"}, messages)
 }
 
-func TestConsumeToTimestamp(t *testing.T) {
+func TestConsumeToTimestampIntegration(t *testing.T) {
 	testutil.StartIntegrationTest(t)
 
 	topicName := testutil.CreateTopic(t, "consume-topic", "--partitions", "2")

--- a/cmd/consume/consume_test.go
+++ b/cmd/consume/consume_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/riferrei/srclient"
-
+	"github.com/deviceinsight/kafkactl/v5/internal"
 	"github.com/deviceinsight/kafkactl/v5/internal/helpers/protobuf"
+	"github.com/riferrei/srclient"
 
 	"github.com/deviceinsight/kafkactl/v5/internal/testutil"
 	"github.com/jhump/protoreflect/dynamic"
@@ -18,7 +18,6 @@ import (
 )
 
 func TestConsumeWithKeyAndValueIntegration(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 
 	topicName := testutil.CreateTopic(t, "consume-topic")
@@ -35,7 +34,6 @@ func TestConsumeWithKeyAndValueIntegration(t *testing.T) {
 }
 
 func TestConsumeWithPartitionAndValueIntegration(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 
 	topicName := testutil.CreateTopic(t, "consume-topic", "--partitions", "2")
@@ -52,7 +50,6 @@ func TestConsumeWithPartitionAndValueIntegration(t *testing.T) {
 }
 
 func TestConsumeWithEmptyPartitionsIntegration(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 
 	topicName := testutil.CreateTopic(t, "consume-topic", "--partitions", "10")
@@ -69,7 +66,6 @@ func TestConsumeWithEmptyPartitionsIntegration(t *testing.T) {
 }
 
 func TestConsumeTailIntegration(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 
 	topicName := testutil.CreateTopic(t, "consume-topic", "--partitions", "10")
@@ -97,7 +93,6 @@ func TestConsumeTailIntegration(t *testing.T) {
 }
 
 func TestConsumeFromTimestamp(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 
 	topicName := testutil.CreateTopic(t, "consume-topic", "--partitions", "2")
@@ -119,7 +114,7 @@ func TestConsumeFromTimestamp(t *testing.T) {
 	testutil.ProduceMessageOnPartition(t, topicName, "key-2", "g", 1, 3)
 	testutil.ProduceMessageOnPartition(t, topicName, "key-1", "h", 0, 3)
 
-	//test --from-timestamp with --to-timestamp with formatted dates
+	// test --from-timestamp with --to-timestamp with formatted dates
 	kafkaCtl := testutil.CreateKafkaCtlCommand()
 	t1Formatted := time.UnixMilli(t1).Format("2006-01-02T15:04:05.123Z")
 	t2Formatted := time.UnixMilli(t2).Format("2006-01-02T15:04:05.123Z")
@@ -129,7 +124,7 @@ func TestConsumeFromTimestamp(t *testing.T) {
 	messages := strings.Split(strings.TrimSpace(kafkaCtl.GetStdOut()), "\n")
 	testutil.AssertArraysEquals(t, []string{"c", "d", "e", "f"}, messages)
 
-	//test --from-timestamp with --to-timestamp with unix epoch millis timestamps
+	// test --from-timestamp with --to-timestamp with unix epoch millis timestamps
 	kafkaCtl = testutil.CreateKafkaCtlCommand()
 	if _, err := kafkaCtl.Execute("consume", topicName, "--from-timestamp", strconv.FormatInt(t2, 10), "--to-timestamp", strconv.FormatInt(t2, 10)); err != nil {
 		t.Fatalf("failed to execute command: %v", err)
@@ -137,7 +132,7 @@ func TestConsumeFromTimestamp(t *testing.T) {
 	messages = strings.Split(strings.TrimSpace(kafkaCtl.GetStdOut()), "\n")
 	testutil.AssertArraysEquals(t, []string{"c", "d", "e", "f"}, messages)
 
-	//test --from-timestamp with --max-messages (--partitions present for reproducibility)
+	// test --from-timestamp with --max-messages (--partitions present for reproducibility)
 	kafkaCtl = testutil.CreateKafkaCtlCommand()
 	if _, err := kafkaCtl.Execute("consume", topicName, "--from-timestamp", strconv.FormatInt(t1, 10), "--max-messages", strconv.Itoa(2), "--partitions", strconv.Itoa(1)); err != nil {
 		t.Fatalf("failed to execute command: %v", err)
@@ -145,7 +140,7 @@ func TestConsumeFromTimestamp(t *testing.T) {
 	messages = strings.Split(strings.TrimSpace(kafkaCtl.GetStdOut()), "\n")
 	testutil.AssertArraysEquals(t, []string{"c", "d"}, messages)
 
-	//test --from-timestamp with --exit
+	// test --from-timestamp with --exit
 	kafkaCtl = testutil.CreateKafkaCtlCommand()
 	if _, err := kafkaCtl.Execute("consume", topicName, "--from-timestamp", strconv.FormatInt(t2, 10), "--exit"); err != nil {
 		t.Fatalf("failed to execute command: %v", err)
@@ -155,7 +150,6 @@ func TestConsumeFromTimestamp(t *testing.T) {
 }
 
 func TestConsumeToTimestamp(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 
 	topicName := testutil.CreateTopic(t, "consume-topic", "--partitions", "2")
@@ -177,7 +171,7 @@ func TestConsumeToTimestamp(t *testing.T) {
 	testutil.ProduceMessageOnPartition(t, topicName, "key-2", "g", 1, 3)
 	testutil.ProduceMessageOnPartition(t, topicName, "key-1", "h", 0, 3)
 
-	//test --from-beginning with --to-timestamp
+	// test --from-beginning with --to-timestamp
 	kafkaCtl := testutil.CreateKafkaCtlCommand()
 	if _, err := kafkaCtl.Execute("consume", topicName, "--from-beginning", "--to-timestamp", strconv.FormatInt(t1, 10)); err != nil {
 		t.Fatalf("failed to execute command: %v", err)
@@ -185,7 +179,7 @@ func TestConsumeToTimestamp(t *testing.T) {
 	messages := strings.Split(strings.TrimSpace(kafkaCtl.GetStdOut()), "\n")
 	testutil.AssertArraysEquals(t, []string{"a", "b"}, messages)
 
-	//test --to-timestamp with --tail
+	// test --to-timestamp with --tail
 	kafkaCtl = testutil.CreateKafkaCtlCommand()
 	if _, err := kafkaCtl.Execute("consume", topicName, "--to-timestamp", strconv.FormatInt(t2, 10), "--tail", strconv.Itoa(4)); err != nil {
 		t.Fatalf("failed to execute command: %v", err)
@@ -195,7 +189,6 @@ func TestConsumeToTimestamp(t *testing.T) {
 }
 
 func TestConsumeWithKeyAndValueAsBase64Integration(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 
 	topicName := testutil.CreateTopic(t, "consume-topic")
@@ -215,7 +208,6 @@ func TestConsumeWithKeyAndValueAsBase64Integration(t *testing.T) {
 }
 
 func TestConsumeWithKeyAndValueAsHexIntegration(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 
 	topicName := testutil.CreateTopic(t, "consume-topic")
@@ -235,7 +227,6 @@ func TestConsumeWithKeyAndValueAsHexIntegration(t *testing.T) {
 }
 
 func TestConsumeWithKeyAndValueAutoDetectBinaryValueIntegration(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 
 	topicName := testutil.CreateTopic(t, "consume-topic")
@@ -261,7 +252,6 @@ func TestConsumeWithKeyAndValueAutoDetectBinaryValueIntegration(t *testing.T) {
 }
 
 func TestAvroDeserializationErrorHandlingIntegration(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 
 	valueSchema := `{
@@ -338,7 +328,7 @@ func TestProtobufConsumeProtoFileIntegration(t *testing.T) {
 
 	protoPath := filepath.Join(testutil.RootDir, "internal", "testutil", "testdata")
 	now := time.Date(2021, time.December, 1, 14, 10, 12, 0, time.UTC)
-	pbMessageDesc := protobuf.ResolveMessageType(protobuf.SearchContext{
+	pbMessageDesc := protobuf.ResolveMessageType(internal.ProtobufConfig{
 		ProtoImportPaths: []string{protoPath},
 		ProtoFiles:       []string{"msg.proto"},
 	}, "TopicMessage")
@@ -374,7 +364,7 @@ func TestProtobufConsumeProtoFileWithoutProtoImportPathIntegration(t *testing.T)
 
 	protoPath := filepath.Join(testutil.RootDir, "internal", "testutil", "testdata")
 	now := time.Date(2021, time.December, 1, 14, 10, 12, 0, time.UTC)
-	pbMessageDesc := protobuf.ResolveMessageType(protobuf.SearchContext{
+	pbMessageDesc := protobuf.ResolveMessageType(internal.ProtobufConfig{
 		ProtoImportPaths: []string{protoPath},
 		ProtoFiles:       []string{"msg.proto"},
 	}, "TopicMessage")
@@ -430,7 +420,7 @@ func TestProtobufConsumeProtosetFileIntegration(t *testing.T) {
 
 	protoPath := filepath.Join(testutil.RootDir, "internal", "testutil", "testdata", "msg.protoset")
 	now := time.Date(2021, time.December, 1, 14, 10, 12, 0, time.UTC)
-	pbMessageDesc := protobuf.ResolveMessageType(protobuf.SearchContext{
+	pbMessageDesc := protobuf.ResolveMessageType(internal.ProtobufConfig{
 		ProtosetFiles: []string{protoPath},
 	}, "TopicMessage")
 	pbMessage := dynamic.NewMessage(pbMessageDesc)
@@ -465,7 +455,7 @@ func TestProtobufConsumeProtoFileErrNoMessageIntegration(t *testing.T) {
 
 	protoPath := filepath.Join(testutil.RootDir, "internal", "testutil", "testdata", "msg.protoset")
 	now := time.Date(2021, time.December, 1, 14, 10, 12, 0, time.UTC)
-	pbMessageDesc := protobuf.ResolveMessageType(protobuf.SearchContext{
+	pbMessageDesc := protobuf.ResolveMessageType(internal.ProtobufConfig{
 		ProtosetFiles: []string{protoPath},
 	}, "TopicMessage")
 	pbMessage := dynamic.NewMessage(pbMessageDesc)
@@ -515,7 +505,6 @@ func TestProtobufConsumeProtoFileErrDecodeIntegration(t *testing.T) {
 }
 
 func TestConsumeGroupIntegration(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 
 	prefix := "consume-group-"
@@ -549,7 +538,6 @@ func TestConsumeGroupIntegration(t *testing.T) {
 }
 
 func TestConsumeAutoCompletionIntegration(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 
 	prefix := "consume-complete-"
@@ -573,7 +561,6 @@ func TestConsumeAutoCompletionIntegration(t *testing.T) {
 }
 
 func TestConsumeGroupCompletionIntegration(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 
 	prefix := "consume-group-complete-"
@@ -599,7 +586,6 @@ func TestConsumeGroupCompletionIntegration(t *testing.T) {
 }
 
 func TestConsumePartitionsK8sIntegration(t *testing.T) {
-
 	testutil.StartIntegrationTestWithContext(t, "k8s-mock")
 
 	kafkaCtl := testutil.CreateKafkaCtlCommand()
@@ -628,7 +614,6 @@ func TestConsumePartitionsK8sIntegration(t *testing.T) {
 		},
 	} {
 		t.Run(test.description, func(t *testing.T) {
-
 			if _, err := kafkaCtl.Execute(test.args...); err != nil {
 				t.Fatalf("failed to execute command: %v", err)
 			}

--- a/cmd/produce/produce.go
+++ b/cmd/produce/produce.go
@@ -11,10 +11,9 @@ import (
 )
 
 func NewProduceCmd() *cobra.Command {
-
 	var flags producer.Flags
 
-	var cmdProduce = &cobra.Command{
+	cmdProduce := &cobra.Command{
 		Use:   "produce TOPIC",
 		Short: "produce messages to a topic",
 		Args:  cobra.ExactArgs(1),

--- a/cmd/produce/produce_test.go
+++ b/cmd/produce/produce_test.go
@@ -91,7 +91,7 @@ func TestProduceAvroMessageWithHeadersIntegration(t *testing.T) {
 	testutil.AssertEquals(t, fmt.Sprintf("key1:value1,key\\:2:value\\:2#test-key#%s", value), kafkaCtl.GetStdOut())
 }
 
-func TestProduceAvroMessageOmitDefaultValue(t *testing.T) {
+func TestProduceAvroMessageOmitDefaultValueIntegration(t *testing.T) {
 	testutil.StartIntegrationTest(t)
 
 	valueSchema := `{
@@ -126,7 +126,7 @@ func TestProduceAvroMessageOmitDefaultValue(t *testing.T) {
 	testutil.AssertContainSubstring(t, `"ExpiresOn":null`, stdout)
 }
 
-func TestProduceAvroMessageWithUnionStandardJson(t *testing.T) {
+func TestProduceAvroMessageWithUnionStandardJsonIntegration(t *testing.T) {
 	testutil.StartIntegrationTest(t)
 
 	valueSchema := `{
@@ -191,7 +191,7 @@ func TestProduceRegistryProtobufMessageWithHeadersIntegration(t *testing.T) {
 	testutil.AssertEquals(t, fmt.Sprintf("key1:value1,key\\:2:value\\:2#test-key#%s", value), kafkaCtl.GetStdOut())
 }
 
-func TestProduceRegistryProtobufMessageOmitDefaultValue(t *testing.T) {
+func TestProduceRegistryProtobufMessageOmitDefaultValueIntegration(t *testing.T) {
 	testutil.StartIntegrationTest(t)
 
 	valueSchema := `syntax = "proto3";
@@ -218,11 +218,11 @@ func TestProduceRegistryProtobufMessageOmitDefaultValue(t *testing.T) {
 	}
 
 	stdout := kafkaCtl.GetStdOut()
-	testutil.AssertContainSubstring(t, `"CurrencyCode":"EUR"`, stdout)
-	testutil.AssertContainSubstring(t, `"ExpiresOn":null`, stdout)
+	testutil.AssertContainSubstring(t, `"currentCode":"EUR"`, stdout)
+	testutil.AssertContainSubstring(t, `"expiresOn":""`, stdout)
 }
 
-func TestProduceJsonMessageWithSchema(t *testing.T) {
+func TestProduceJsonMessageWithSchemaIntegration(t *testing.T) {
 	testutil.StartIntegrationTest(t)
 
 	valueSchema := `{
@@ -267,7 +267,7 @@ func TestProduceJsonMessageWithSchema(t *testing.T) {
 	testutil.AssertContainSubstring(t, `"ExpiresOn": "2022-12-12"`, stdout)
 }
 
-func TestProduceAvroMessageWithUnionAvroJson(t *testing.T) {
+func TestProduceAvroMessageWithUnionAvroJsonIntegration(t *testing.T) {
 	testutil.StartIntegrationTest(t)
 
 	valueSchema := `{

--- a/cmd/produce/produce_test.go
+++ b/cmd/produce/produce_test.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/riferrei/srclient"
-
+	"github.com/deviceinsight/kafkactl/v5/internal"
 	"github.com/deviceinsight/kafkactl/v5/internal/helpers/protobuf"
+	"github.com/riferrei/srclient"
 
 	"github.com/jhump/protoreflect/dynamic"
 
@@ -20,7 +20,6 @@ import (
 )
 
 func TestProduceWithKeyAndValueIntegration(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 
 	topicName := testutil.CreateTopic(t, "produce-topic")
@@ -41,7 +40,6 @@ func TestProduceWithKeyAndValueIntegration(t *testing.T) {
 }
 
 func TestProduceMessageWithHeadersIntegration(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 
 	topicName := testutil.CreateTopic(t, "produce-topic")
@@ -62,7 +60,6 @@ func TestProduceMessageWithHeadersIntegration(t *testing.T) {
 }
 
 func TestProduceAvroMessageWithHeadersIntegration(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 
 	valueSchema := `{
@@ -95,7 +92,6 @@ func TestProduceAvroMessageWithHeadersIntegration(t *testing.T) {
 }
 
 func TestProduceAvroMessageOmitDefaultValue(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 
 	valueSchema := `{
@@ -131,7 +127,6 @@ func TestProduceAvroMessageOmitDefaultValue(t *testing.T) {
 }
 
 func TestProduceAvroMessageWithUnionStandardJson(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 
 	valueSchema := `{
@@ -168,8 +163,66 @@ func TestProduceAvroMessageWithUnionStandardJson(t *testing.T) {
 	testutil.AssertContainSubstring(t, `"ExpiresOn":"2022-12-12"`, stdout)
 }
 
-func TestProduceJsonMessageWithSchema(t *testing.T) {
+func TestProduceRegistryProtobufMessageWithHeadersIntegration(t *testing.T) {
+	testutil.StartIntegrationTest(t)
 
+	valueSchema := `syntax = "proto3";
+  package foo.bar;
+
+  message Msg {
+    string name = 1;
+  }`
+	value := `{"name":"Peter Mueller"}`
+
+	topicName := testutil.CreateTopicWithSchema(t, "produce-protobuf-topic", "", valueSchema, srclient.Protobuf)
+
+	kafkaCtl := testutil.CreateKafkaCtlCommand()
+
+	if _, err := kafkaCtl.Execute("produce", topicName, "--key", "test-key", "--value", value, "-H", "key1:value1", "-H", "key\\:2:value\\:2"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	testutil.AssertEquals(t, "message produced (partition=0\toffset=0)", kafkaCtl.GetStdOut())
+
+	if _, err := kafkaCtl.Execute("consume", topicName, "--from-beginning", "--exit", "--print-keys", "--print-headers"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	testutil.AssertEquals(t, fmt.Sprintf("key1:value1,key\\:2:value\\:2#test-key#%s", value), kafkaCtl.GetStdOut())
+}
+
+func TestProduceRegistryProtobufMessageOmitDefaultValue(t *testing.T) {
+	testutil.StartIntegrationTest(t)
+
+	valueSchema := `syntax = "proto3";
+  package foo.bar;
+
+  message Msg {
+    string current_code = 1;
+    string expires_on = 2;
+  }`
+	value := `{"currentCode":"EUR"}`
+
+	topicName := testutil.CreateTopicWithSchema(t, "produce-protobuf-topic", "", valueSchema, srclient.Protobuf)
+
+	kafkaCtl := testutil.CreateKafkaCtlCommand()
+
+	if _, err := kafkaCtl.Execute("produce", topicName, "--value", value); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	testutil.AssertEquals(t, "message produced (partition=0\toffset=0)", kafkaCtl.GetStdOut())
+
+	if _, err := kafkaCtl.Execute("consume", topicName, "--from-beginning", "--exit"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	stdout := kafkaCtl.GetStdOut()
+	testutil.AssertContainSubstring(t, `"CurrencyCode":"EUR"`, stdout)
+	testutil.AssertContainSubstring(t, `"ExpiresOn":null`, stdout)
+}
+
+func TestProduceJsonMessageWithSchema(t *testing.T) {
 	testutil.StartIntegrationTest(t)
 
 	valueSchema := `{
@@ -215,7 +268,6 @@ func TestProduceJsonMessageWithSchema(t *testing.T) {
 }
 
 func TestProduceAvroMessageWithUnionAvroJson(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 
 	valueSchema := `{
@@ -257,7 +309,6 @@ func TestProduceAvroMessageWithUnionAvroJson(t *testing.T) {
 }
 
 func TestProduceTombstoneIntegration(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 
 	topicName := testutil.CreateTopic(t, "produce-topic")
@@ -279,7 +330,6 @@ func TestProduceTombstoneIntegration(t *testing.T) {
 }
 
 func TestProduceFromBase64Integration(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 
 	topicName := testutil.CreateTopic(t, "produce-topic")
@@ -302,7 +352,6 @@ func TestProduceFromBase64Integration(t *testing.T) {
 }
 
 func TestProduceFromHexIntegration(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 
 	topicName := testutil.CreateTopic(t, "produce-topic")
@@ -325,7 +374,6 @@ func TestProduceFromHexIntegration(t *testing.T) {
 }
 
 func TestProduceAutoCompletionIntegration(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 
 	prefix := "produce-complete-"
@@ -385,11 +433,11 @@ func TestProduceProtoFileIntegration(t *testing.T) {
 		t.Fatalf("Failed to decode value: %s", err)
 	}
 
-	keyMessage := dynamic.NewMessage(protobuf.ResolveMessageType(protobuf.SearchContext{
+	keyMessage := dynamic.NewMessage(protobuf.ResolveMessageType(internal.ProtobufConfig{
 		ProtoImportPaths: []string{protoPath},
 		ProtoFiles:       []string{"msg.proto"},
 	}, "TopicKey"))
-	valueMessage := dynamic.NewMessage(protobuf.ResolveMessageType(protobuf.SearchContext{
+	valueMessage := dynamic.NewMessage(protobuf.ResolveMessageType(internal.ProtobufConfig{
 		ProtoImportPaths: []string{protoPath},
 		ProtoFiles:       []string{"msg.proto"},
 	}, "TopicMessage"))
@@ -416,7 +464,6 @@ func TestProduceProtoFileIntegration(t *testing.T) {
 }
 
 func TestProduceWithCSVFileIntegration(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 	topic := testutil.CreateTopic(t, "produce-topic-csv")
 	kafkaCtl := testutil.CreateKafkaCtlCommand()
@@ -438,7 +485,6 @@ func TestProduceWithCSVFileIntegration(t *testing.T) {
 }
 
 func TestProduceWithCSVFileWithTimestampsFirstColumnIntegration(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 	topic := testutil.CreateTopic(t, "produce-topic-csv")
 	kafkaCtl := testutil.CreateKafkaCtlCommand()
@@ -460,7 +506,6 @@ func TestProduceWithCSVFileWithTimestampsFirstColumnIntegration(t *testing.T) {
 }
 
 func TestProduceWithCSVFileWithTimestampsSecondColumnIntegration(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 	topic := testutil.CreateTopic(t, "produce-topic-csv")
 	kafkaCtl := testutil.CreateKafkaCtlCommand()
@@ -482,7 +527,6 @@ func TestProduceWithCSVFileWithTimestampsSecondColumnIntegration(t *testing.T) {
 }
 
 func TestProduceWithJSONFileIntegration(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 	topic := testutil.CreateTopic(t, "produce-topic-json")
 	kafkaCtl := testutil.CreateKafkaCtlCommand()
@@ -505,7 +549,6 @@ func TestProduceWithJSONFileIntegration(t *testing.T) {
 }
 
 func TestProduceWithJSONFileBase64ValuesIntegration(t *testing.T) {
-
 	testutil.StartIntegrationTest(t)
 	topic := testutil.CreateTopic(t, "produce-topic-json-base64-values")
 	kafkaCtl := testutil.CreateKafkaCtlCommand()
@@ -559,7 +602,7 @@ func TestProduceProtoFileWithOnlyKeyEncodedIntegration(t *testing.T) {
 		t.Fatalf("Failed to decode key: %s", err)
 	}
 
-	keyMessage := dynamic.NewMessage(protobuf.ResolveMessageType(protobuf.SearchContext{
+	keyMessage := dynamic.NewMessage(protobuf.ResolveMessageType(internal.ProtobufConfig{
 		ProtoImportPaths: []string{protoPath},
 		ProtoFiles:       []string{"msg.proto"},
 	}, "TopicKey"))
@@ -616,11 +659,11 @@ func TestProduceProtoFileWithoutProtoImportPathIntegration(t *testing.T) {
 		t.Fatalf("Failed to decode value: %s", err)
 	}
 
-	keyMessage := dynamic.NewMessage(protobuf.ResolveMessageType(protobuf.SearchContext{
+	keyMessage := dynamic.NewMessage(protobuf.ResolveMessageType(internal.ProtobufConfig{
 		ProtoImportPaths: []string{protoPath},
 		ProtoFiles:       []string{"msg.proto"},
 	}, "TopicKey"))
-	valueMessage := dynamic.NewMessage(protobuf.ResolveMessageType(protobuf.SearchContext{
+	valueMessage := dynamic.NewMessage(protobuf.ResolveMessageType(internal.ProtobufConfig{
 		ProtoImportPaths: []string{protoPath},
 		ProtoFiles:       []string{"msg.proto"},
 	}, "TopicMessage"))
@@ -683,10 +726,10 @@ func TestProduceProtosetFileIntegration(t *testing.T) {
 		t.Fatalf("Failed to decode value: %s", err)
 	}
 
-	keyMessage := dynamic.NewMessage(protobuf.ResolveMessageType(protobuf.SearchContext{
+	keyMessage := dynamic.NewMessage(protobuf.ResolveMessageType(internal.ProtobufConfig{
 		ProtosetFiles: []string{protoPath},
 	}, "TopicKey"))
-	valueMessage := dynamic.NewMessage(protobuf.ResolveMessageType(protobuf.SearchContext{
+	valueMessage := dynamic.NewMessage(protobuf.ResolveMessageType(internal.ProtobufConfig{
 		ProtosetFiles: []string{protoPath},
 	}, "TopicMessage"))
 

--- a/internal/CachingSchemaRegistry.go
+++ b/internal/CachingSchemaRegistry.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/deviceinsight/kafkactl/v5/internal/helpers/schemaregistry"
@@ -12,7 +13,10 @@ import (
 	"github.com/riferrei/srclient"
 )
 
-const WireFormatBytes = 5
+const (
+	WireFormatBytes = 5
+	MagicByte       = 0
+)
 
 type CachingSchemaRegistry struct {
 	srclient.ISchemaRegistryClient
@@ -64,12 +68,41 @@ func (registry *CachingSchemaRegistry) GetSubjects() ([]string, error) {
 	return registry.subjects, err
 }
 
+func (registry *CachingSchemaRegistry) SubjectOfTypeExists(subject string, expectedSchemaType srclient.SchemaType) (bool, error) {
+	subjects, err := registry.GetSubjects()
+	if err != nil {
+		return false, errors.Wrap(err, "failed to list available avro schemas")
+	}
+
+	if !slices.Contains(subjects, subject) {
+		return false, nil
+	}
+
+	schema, err := registry.GetLatestSchema(subject)
+	if err != nil {
+		return false, errors.Wrap(err, fmt.Sprintf("failed to retrieve latest schema for subject %s", subject))
+	}
+
+	if schema.SchemaType() == nil && expectedSchemaType == srclient.Avro {
+		return true, nil
+	}
+
+	if schema.SchemaType() == nil {
+		return false, nil
+	}
+
+	if *schema.SchemaType() != expectedSchemaType {
+		return false, nil
+	}
+	return true, nil
+}
+
 func (registry *CachingSchemaRegistry) ExtractSchemaID(data []byte) (int, error) {
 	if len(data) < WireFormatBytes {
 		return 0, fmt.Errorf("data too short. cannot extra schema id from message (len = %d)", len(data))
 	}
 
-	if data[0] != 0 {
+	if data[0] != MagicByte {
 		return 0, fmt.Errorf("confluent serialization format version number was %d != 0", data[0])
 	}
 

--- a/internal/CachingSchemaRegistry.go
+++ b/internal/CachingSchemaRegistry.go
@@ -71,7 +71,7 @@ func (registry *CachingSchemaRegistry) GetSubjects() ([]string, error) {
 func (registry *CachingSchemaRegistry) SubjectOfTypeExists(subject string, expectedSchemaType srclient.SchemaType) (bool, error) {
 	subjects, err := registry.GetSubjects()
 	if err != nil {
-		return false, errors.Wrap(err, "failed to list available avro schemas")
+		return false, errors.Wrap(err, "failed to list available schemas")
 	}
 
 	if !slices.Contains(subjects, subject) {

--- a/internal/consume/AvroMessageDeserializer.go
+++ b/internal/consume/AvroMessageDeserializer.go
@@ -17,7 +17,6 @@ type AvroMessageDeserializer struct {
 }
 
 func (deserializer *AvroMessageDeserializer) canDeserialize(consumerMsg *sarama.ConsumerMessage, data []byte) bool {
-
 	schemaID, err := deserializer.registry.ExtractSchemaID(data)
 	if err == nil {
 		schema, schemaErr := deserializer.registry.GetSchema(schemaID)
@@ -36,17 +35,18 @@ func (deserializer *AvroMessageDeserializer) canDeserialize(consumerMsg *sarama.
 }
 
 func (deserializer *AvroMessageDeserializer) CanDeserializeKey(consumerMsg *sarama.ConsumerMessage,
-	flags Flags) bool {
+	flags Flags,
+) bool {
 	return flags.KeyProtoType == "" && deserializer.canDeserialize(consumerMsg, consumerMsg.Key)
 }
 
 func (deserializer *AvroMessageDeserializer) CanDeserializeValue(consumerMsg *sarama.ConsumerMessage,
-	flags Flags) bool {
+	flags Flags,
+) bool {
 	return flags.ValueProtoType == "" && deserializer.canDeserialize(consumerMsg, consumerMsg.Value)
 }
 
 func (deserializer *AvroMessageDeserializer) deserialize(data []byte) (*DeserializedData, error) {
-
 	schemaID, err := deserializer.registry.ExtractSchemaID(data)
 	if err != nil {
 		return nil, err

--- a/internal/consume/ProtobufAnyTypeResolver.go
+++ b/internal/consume/ProtobufAnyTypeResolver.go
@@ -1,0 +1,27 @@
+package consume
+
+import (
+	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+// An implementation of protojson's Resolver interface.
+// Overriding the default resolver allows to ignore unknown protobuf.Any fields
+type ignoreUnrecognizedAny struct {
+	protoregistry.ExtensionTypeResolver
+}
+
+func (*ignoreUnrecognizedAny) FindMessageByName(name protoreflect.FullName) (protoreflect.MessageType, error) {
+	if result, err := protoregistry.GlobalTypes.FindMessageByName(name); err == nil {
+		return result, nil
+	}
+	return (&empty.Empty{}).ProtoReflect().Type(), nil
+}
+
+func (*ignoreUnrecognizedAny) FindMessageByURL(url string) (protoreflect.MessageType, error) {
+	if result, err := protoregistry.GlobalTypes.FindMessageByURL(url); err == nil {
+		return result, nil
+	}
+	return (&empty.Empty{}).ProtoReflect().Type(), nil
+}

--- a/internal/consume/ProtobufMessageDeserializer.go
+++ b/internal/consume/ProtobufMessageDeserializer.go
@@ -2,6 +2,7 @@ package consume
 
 import (
 	"github.com/IBM/sarama"
+	"github.com/deviceinsight/kafkactl/v5/internal"
 	"github.com/deviceinsight/kafkactl/v5/internal/helpers/protobuf"
 	"github.com/deviceinsight/kafkactl/v5/internal/output"
 	"github.com/jhump/protoreflect/desc"
@@ -16,9 +17,7 @@ type ProtobufMessageDeserializer struct {
 	valueDescriptor *desc.MessageDescriptor
 }
 
-func CreateProtobufMessageDeserializer(context protobuf.SearchContext,
-	keyType, valueType string) (*ProtobufMessageDeserializer, error) {
-
+func CreateProtobufMessageDeserializer(context internal.ProtobufConfig, keyType, valueType string) (*ProtobufMessageDeserializer, error) {
 	return &ProtobufMessageDeserializer{
 		keyType:         keyType,
 		valueType:       valueType,

--- a/internal/consume/RegistryProtobufMessageDeserializer.go
+++ b/internal/consume/RegistryProtobufMessageDeserializer.go
@@ -1,0 +1,167 @@
+package consume
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/IBM/sarama"
+	"github.com/deviceinsight/kafkactl/v5/internal"
+	"github.com/deviceinsight/kafkactl/v5/internal/output"
+	"github.com/jhump/protoreflect/desc"
+	"github.com/jhump/protoreflect/desc/protoparse"
+	"github.com/riferrei/srclient"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+type RegistryProtobufMessageDeserializer struct {
+	registry *internal.CachingSchemaRegistry
+}
+
+func (deserializer RegistryProtobufMessageDeserializer) canDeserialize(consumerMsg *sarama.ConsumerMessage, data []byte) bool {
+	schemaID, err := deserializer.registry.ExtractSchemaID(data)
+	if err == nil {
+		schema, schemaErr := deserializer.registry.GetSchema(schemaID)
+		if schemaErr != nil {
+			output.Debugf("schema not found. id=%d partition=%d, offset=%d error=%v", schemaID,
+				consumerMsg.Partition, consumerMsg.Offset, err)
+			return false
+		}
+		isProtobufSchema := *schema.SchemaType() == srclient.Protobuf
+		return isProtobufSchema
+	}
+	output.Debugf("failed to extract schema id. partition=%d, offset=%d error=%v", consumerMsg.Partition,
+		consumerMsg.Offset, err)
+	return false
+}
+
+func (deserializer RegistryProtobufMessageDeserializer) CanDeserializeValue(msg *sarama.ConsumerMessage, flags Flags) bool {
+	return deserializer.canDeserialize(msg, msg.Value)
+}
+
+func (deserializer RegistryProtobufMessageDeserializer) CanDeserializeKey(msg *sarama.ConsumerMessage, flags Flags) bool {
+	return deserializer.canDeserialize(msg, msg.Key)
+}
+
+func (deserializer RegistryProtobufMessageDeserializer) DeserializeValue(msg *sarama.ConsumerMessage) (*DeserializedData, error) {
+	return deserializer.deserialize(msg.Value)
+}
+
+func (deserializer RegistryProtobufMessageDeserializer) DeserializeKey(msg *sarama.ConsumerMessage) (*DeserializedData, error) {
+	return deserializer.deserialize(msg.Key)
+}
+
+func (deserializer RegistryProtobufMessageDeserializer) deserialize(rawData []byte) (*DeserializedData, error) {
+	schemaID, err := deserializer.registry.ExtractSchemaID(rawData)
+	schema, err := deserializer.registry.GetSchema(schemaID)
+	if err != nil {
+		return nil, err
+	}
+	output.Debugf("fetched schema %d", schemaID)
+	resolvedSchemas, err := deserializer.resolveDependencies(schema.References())
+	if err != nil {
+		return nil, err
+	}
+	resolvedSchemas["."] = schema.Schema()
+	fileDesc, err := deserializer.schemaToFileDescriptor(schema)
+	if err != nil {
+		return nil, err
+	}
+	indexes, bytes, err := readIndexes(rawData[5:])
+	if err != nil {
+		return nil, err
+	}
+	messageDescriptor, err := findMessageDescriptor(indexes, fileDesc.GetMessageTypes())
+	if err != nil {
+		return nil, err
+	}
+	dynmsg := dynamicpb.NewMessage(messageDescriptor.UnwrapMessage())
+	err = proto.Unmarshal(rawData[5+bytes:], dynmsg)
+	if err != nil {
+		return nil, err
+	}
+
+	asJsonBytes, err := protojson.MarshalOptions{
+		Multiline:       false,
+		EmitUnpopulated: true,
+		AllowPartial:    true,
+		Resolver:        &ignoreUnrecognizedAny{protoregistry.GlobalTypes},
+	}.Marshal(dynmsg)
+	if err != nil {
+		return nil, err
+	}
+
+	schemaString := schema.Schema()
+
+	return &DeserializedData{
+		data:     asJsonBytes,
+		schema:   schemaString,
+		schemaID: &schemaID,
+	}, nil
+}
+
+func readIndexes(rawData []byte) ([]int64, int, error) {
+	length, bytes := binary.Varint(rawData)
+	indexes := []int64{}
+	if bytes < 0 {
+		return nil, 0, fmt.Errorf("can't read varint indexes length: %d", bytes)
+	}
+	if length == 0 {
+		return []int64{0}, bytes, nil
+	}
+	for i := range int(length) {
+		index, readBytes := binary.Varint(rawData[bytes:])
+		if readBytes < 0 {
+			return nil, 0, fmt.Errorf("can't read varint number %d", i)
+		}
+		indexes = append(indexes, index)
+		bytes += readBytes
+	}
+
+	return indexes, bytes, nil
+}
+
+func findMessageDescriptor(indexes []int64, descriptors []*desc.MessageDescriptor) (*desc.MessageDescriptor, error) {
+	if len(indexes) == 0 {
+		return nil, errors.New("indexes can't be empty")
+	} else if len(indexes) == 1 {
+		return descriptors[indexes[0]], nil
+	} else {
+		return findMessageDescriptor(indexes[1:], descriptors)
+	}
+}
+
+func (deserializer RegistryProtobufMessageDeserializer) schemaToFileDescriptor(schema *srclient.Schema) (*desc.FileDescriptor, error) {
+	dependencies, err := deserializer.resolveDependencies(schema.References())
+	if err != nil {
+		return nil, err
+	}
+	dependencies["."] = schema.Schema()
+
+	return parseFileDescriptor(".", dependencies)
+}
+
+func (deserializer RegistryProtobufMessageDeserializer) resolveDependencies(references []srclient.Reference) (map[string]string, error) {
+	resolved := map[string]string{}
+	for _, r := range references {
+		latest, err := deserializer.registry.GetLatestSchema(r.Subject)
+		if err != nil {
+			return map[string]string{}, err
+		}
+		resolved[r.Subject] = latest.Schema()
+	}
+
+	return resolved, nil
+}
+
+func parseFileDescriptor(filename string, resolvedSchemas map[string]string) (*desc.FileDescriptor, error) {
+	parser := protoparse.Parser{Accessor: protoparse.FileContentsFromMap(resolvedSchemas)}
+	parsedFiles, err := parser.ParseFiles(filename)
+	if err != nil {
+		return nil, err
+	}
+	return parsedFiles[0], nil
+}

--- a/internal/helpers/protobuf/protobuf.go
+++ b/internal/helpers/protobuf/protobuf.go
@@ -1,24 +1,84 @@
 package protobuf
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/descriptorpb"
 
+	"github.com/deviceinsight/kafkactl/v5/internal"
 	"github.com/deviceinsight/kafkactl/v5/internal/output"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/desc/protoparse"
+	"github.com/pkg/errors"
+	"github.com/riferrei/srclient"
 )
 
-type SearchContext struct {
-	ProtosetFiles    []string
-	ProtoFiles       []string
-	ProtoImportPaths []string
+func SchemaToFileDescriptor(registry srclient.ISchemaRegistryClient, schema *srclient.Schema) (*desc.FileDescriptor, error) {
+	dependencies, err := resolveDependencies(registry, schema.References())
+	if err != nil {
+		return nil, err
+	}
+	dependencies["."] = schema.Schema()
+
+	return ParseFileDescriptor(".", dependencies)
 }
 
-func ResolveMessageType(context SearchContext, typeName string) *desc.MessageDescriptor {
+func resolveDependencies(registry srclient.ISchemaRegistryClient, references []srclient.Reference) (map[string]string, error) {
+	resolved := map[string]string{}
+	for _, r := range references {
+		latest, err := registry.GetLatestSchema(r.Subject)
+		if err != nil {
+			return map[string]string{}, errors.Wrap(err, fmt.Sprintf("couldn't fetch latest schema for subject %s", r.Subject))
+		}
+		resolved[r.Subject] = latest.Schema()
+	}
+
+	return resolved, nil
+}
+
+func ParseFileDescriptor(filename string, resolvedSchemas map[string]string) (*desc.FileDescriptor, error) {
+	parser := protoparse.Parser{Accessor: protoparse.FileContentsFromMap(resolvedSchemas)}
+	parsedFiles, err := parser.ParseFiles(filename)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't parse file descriptor")
+	}
+	return parsedFiles[0], nil
+}
+
+func ComputeIndexes(fileDesc *desc.FileDescriptor, msgName string) ([]int64, error) {
+	result := make([]int64, 0, 16)
+	if len(fileDesc.GetMessageTypes()) > 0 && fileDesc.GetMessageTypes()[0].GetFullyQualifiedName() == msgName {
+		return result, nil
+	}
+
+	messages := fileDesc.GetMessageTypes()
+	found := false
+
+	for {
+		found = false
+		for i, message := range messages {
+			if message.GetFullyQualifiedName() == msgName {
+				return append(result, int64(i)), nil
+			}
+
+			if strings.Contains(msgName, message.GetFullyQualifiedName()+".") {
+				found = true
+				result = append(result, int64(i))
+				messages = message.GetNestedMessageTypes()
+				break
+			}
+		}
+		if !found {
+			return nil, errors.Errorf("can't compute indexes for %s", msgName)
+		}
+	}
+}
+
+func ResolveMessageType(context internal.ProtobufConfig, typeName string) *desc.MessageDescriptor {
 	for _, descriptor := range makeDescriptors(context) {
 		if msg := descriptor.FindMessage(typeName); msg != nil {
 			return msg
@@ -28,7 +88,7 @@ func ResolveMessageType(context SearchContext, typeName string) *desc.MessageDes
 	return nil
 }
 
-func makeDescriptors(context SearchContext) []*desc.FileDescriptor {
+func makeDescriptors(context internal.ProtobufConfig) []*desc.FileDescriptor {
 	var ret []*desc.FileDescriptor
 
 	ret = appendProtosets(ret, context.ProtosetFiles)

--- a/internal/helpers/protobuf/protobuf.go
+++ b/internal/helpers/protobuf/protobuf.go
@@ -30,11 +30,11 @@ func SchemaToFileDescriptor(registry srclient.ISchemaRegistryClient, schema *src
 func resolveDependencies(registry srclient.ISchemaRegistryClient, references []srclient.Reference) (map[string]string, error) {
 	resolved := map[string]string{}
 	for _, r := range references {
-		latest, err := registry.GetLatestSchema(r.Subject)
+		refSchema, err := registry.GetSchemaByVersion(r.Subject, r.Version)
 		if err != nil {
 			return map[string]string{}, errors.Wrap(err, fmt.Sprintf("couldn't fetch latest schema for subject %s", r.Subject))
 		}
-		resolved[r.Subject] = latest.Schema()
+		resolved[r.Subject] = refSchema.Schema()
 	}
 
 	return resolved, nil

--- a/internal/helpers/protobuf/protobuf_test.go
+++ b/internal/helpers/protobuf/protobuf_test.go
@@ -1,0 +1,82 @@
+package protobuf
+
+import (
+	"slices"
+	"testing"
+)
+
+const schema = `syntax = "proto3";
+package foo.bar;
+
+message Outer {       // Level 0
+  message MiddleAA {  // Level 1
+    message Inner {   // Level 2
+      int64 ival = 1;
+      bool  booly = 2;
+    }
+  }
+  message MiddleBB {  // Level 1
+    message Inner {   // Level 2
+      int32 ival = 1;
+      bool  booly = 2;
+    }
+  }
+}
+
+message Outer2 {       // Level 0
+  message MiddleAA {  // Level 1
+    message Inner {   // Level 2
+      int64 ival = 1;
+      bool  booly = 2;
+    }
+  }
+  message MiddleBB {  // Level 1
+    message Inner {   // Level 2
+      int32 ival = 1;
+      bool  booly = 2;
+    }
+  }
+}
+`
+
+func TestComputeIndexes(t *testing.T) {
+	testCases := []struct {
+		msgName  string
+		expected []int64
+	}{
+		{"foo.bar.Outer", []int64{}},
+		{"foo.bar.Outer2", []int64{1}},
+		{"foo.bar.Outer.MiddleAA", []int64{0, 0}},
+		{"foo.bar.Outer2.MiddleAA", []int64{1, 0}},
+		{"foo.bar.Outer.MiddleAA.Inner", []int64{0, 0, 0}},
+		{"foo.bar.Outer2.MiddleAA.Inner", []int64{1, 0, 0}},
+	}
+	fileDesc, err := ParseFileDescriptor(".", map[string]string{".": schema})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.msgName, func(t *testing.T) {
+			result, err := ComputeIndexes(fileDesc, tc.msgName)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !slices.Equal(tc.expected, result) {
+				t.Fatalf("expected: %+v, found: %+v", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestComputeIndexesErrorsWhenCantCompute(t *testing.T) {
+	fileDesc, err := ParseFileDescriptor(".", map[string]string{".": schema})
+	if err != nil {
+		t.Fatal(err)
+	}
+	msgName := "foo.bar.MiddleAA"
+	result, err := ComputeIndexes(fileDesc, msgName)
+	if err == nil {
+		t.Fatalf("expected: error, found: %+v", result)
+	}
+}

--- a/internal/helpers/schemaregistry/schema_registry.go
+++ b/internal/helpers/schemaregistry/schema_registry.go
@@ -24,22 +24,22 @@ func FormatBaseURL(baseURL string) string {
 		baseURL = fmt.Sprintf("http://%s", baseURL)
 	}
 
-	parsedURL, err := url.Parse(baseURL)
+	parsedUrl, err := url.Parse(baseURL)
 	if err != nil {
 		panic("Schema registry url invalid")
 	}
 
-	if injectSchema && parsedURL.Port() == "443" {
-		parsedURL.Scheme = "https"
+	if injectSchema && parsedUrl.Port() == "443" {
+		parsedUrl.Scheme = "https"
 	}
 
-	if parsedURL.Port() == "" {
-		if parsedURL.Scheme == "https" {
-			parsedURL.Host = fmt.Sprintf("%s:%s", parsedURL.Hostname(), "443")
+	if parsedUrl.Port() == "" {
+		if parsedUrl.Scheme == "https" {
+			parsedUrl.Host = fmt.Sprintf("%s:%s", parsedUrl.Hostname(), "443")
 		} else {
-			parsedURL.Host = fmt.Sprintf("%s:%s", parsedURL.Hostname(), "80")
+			parsedUrl.Host = fmt.Sprintf("%s:%s", parsedUrl.Hostname(), "80")
 		}
 	}
 
-	return parsedURL.String()
+	return parsedUrl.String()
 }

--- a/internal/helpers/schemaregistry/schema_registry.go
+++ b/internal/helpers/schemaregistry/schema_registry.go
@@ -24,22 +24,22 @@ func FormatBaseURL(baseURL string) string {
 		baseURL = fmt.Sprintf("http://%s", baseURL)
 	}
 
-	parsedUrl, err := url.Parse(baseURL)
+	parsedURL, err := url.Parse(baseURL)
 	if err != nil {
 		panic("Schema registry url invalid")
 	}
 
-	if injectSchema && parsedUrl.Port() == "443" {
-		parsedUrl.Scheme = "https"
+	if injectSchema && parsedURL.Port() == "443" {
+		parsedURL.Scheme = "https"
 	}
 
-	if parsedUrl.Port() == "" {
-		if parsedUrl.Scheme == "https" {
-			parsedUrl.Host = fmt.Sprintf("%s:%s", parsedUrl.Hostname(), "443")
+	if parsedURL.Port() == "" {
+		if parsedURL.Scheme == "https" {
+			parsedURL.Host = fmt.Sprintf("%s:%s", parsedURL.Hostname(), "443")
 		} else {
-			parsedUrl.Host = fmt.Sprintf("%s:%s", parsedUrl.Hostname(), "80")
+			parsedURL.Host = fmt.Sprintf("%s:%s", parsedURL.Hostname(), "80")
 		}
 	}
 
-	return parsedUrl.String()
+	return parsedURL.String()
 }

--- a/internal/producer/DefaultMessageSerializer.go
+++ b/internal/producer/DefaultMessageSerializer.go
@@ -1,38 +1,21 @@
 package producer
 
-import (
-	"github.com/IBM/sarama"
-)
-
 type DefaultMessageSerializer struct {
 	topic string
 }
 
-func (serializer DefaultMessageSerializer) CanSerialize(_ string) (bool, error) {
+func (serializer DefaultMessageSerializer) CanSerializeValue(_ string) (bool, error) {
 	return true, nil
 }
 
-func (serializer DefaultMessageSerializer) Serialize(key, value []byte, flags Flags) (*sarama.ProducerMessage, error) {
+func (serializer DefaultMessageSerializer) CanSerializeKey(_ string) (bool, error) {
+	return true, nil
+}
 
-	recordHeaders, err := createRecordHeaders(flags)
-	if err != nil {
-		return nil, err
-	}
-	message := &sarama.ProducerMessage{Topic: serializer.topic, Partition: flags.Partition, Headers: recordHeaders}
+func (serializer DefaultMessageSerializer) SerializeValue(value []byte, _ Flags) ([]byte, error) {
+	return value, nil
+}
 
-	if key != nil {
-		bytes, err := decodeBytes(key, flags.KeyEncoding)
-		if err != nil {
-			return nil, err
-		}
-		message.Key = sarama.ByteEncoder(bytes)
-	}
-
-	bytes, err := decodeBytes(value, flags.ValueEncoding)
-	if err != nil {
-		return nil, err
-	}
-	message.Value = sarama.ByteEncoder(bytes)
-
-	return message, nil
+func (serializer DefaultMessageSerializer) SerializeKey(key []byte, _ Flags) ([]byte, error) {
+	return key, nil
 }

--- a/internal/producer/MessageSerializer.go
+++ b/internal/producer/MessageSerializer.go
@@ -9,9 +9,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-type MessageSerializer interface {
-	CanSerialize(topic string) (bool, error)
-	Serialize(key, value []byte, flags Flags) (*sarama.ProducerMessage, error)
+type messageSerializer interface {
+	CanSerializeValue(topic string) (bool, error)
+	CanSerializeKey(topic string) (bool, error)
+	SerializeValue(value []byte, flags Flags) ([]byte, error)
+	SerializeKey(key []byte, flags Flags) ([]byte, error)
 }
 
 const (
@@ -20,7 +22,6 @@ const (
 )
 
 func parseHeader(raw string) (key, value string, err error) {
-
 	// use a regex to split in order to handle escaped colons
 	re := regexp.MustCompile(`[^\\]:`)
 

--- a/internal/producer/MessageSerializerChain.go
+++ b/internal/producer/MessageSerializerChain.go
@@ -7,12 +7,36 @@ import (
 
 type MessageSerializerChain struct {
 	topic       string
-	serializers []MessageSerializer
+	serializers []messageSerializer
 }
 
 func (serializer MessageSerializerChain) Serialize(key, value []byte, flags Flags) (*sarama.ProducerMessage, error) {
+	recordHeaders, err := createRecordHeaders(flags)
+	if err != nil {
+		return nil, err
+	}
+	message := &sarama.ProducerMessage{Topic: serializer.topic, Partition: flags.Partition, Headers: recordHeaders}
+
+	if key != nil {
+		bytes, err := serializer.serializeKey(key, flags)
+		if err != nil {
+			return nil, err
+		}
+		message.Key = sarama.ByteEncoder(bytes)
+	}
+
+	bytes, err := serializer.serializeValue(value, flags)
+	if err != nil {
+		return nil, err
+	}
+	message.Value = sarama.ByteEncoder(bytes)
+
+	return message, nil
+}
+
+func (serializer MessageSerializerChain) serializeValue(value []byte, flags Flags) ([]byte, error) {
 	for _, s := range serializer.serializers {
-		canSerialize, err := s.CanSerialize(serializer.topic)
+		canSerialize, err := s.CanSerializeValue(serializer.topic)
 		if err != nil {
 			return nil, err
 		}
@@ -20,28 +44,34 @@ func (serializer MessageSerializerChain) Serialize(key, value []byte, flags Flag
 		if !canSerialize {
 			continue
 		}
+		decodedValue, err := decodeBytes(value, flags.ValueEncoding)
+		if err != nil {
+			return nil, err
+		}
 
-		return s.Serialize(key, value, flags)
+		return s.SerializeValue(decodedValue, flags)
 	}
 
 	return nil, errors.Errorf("can't find suitable serializer")
 }
 
-func (serializer MessageSerializerChain) CanSerialize(topic string) (bool, error) {
-	if serializer.topic != topic {
-		return false, nil
-	}
-
+func (serializer MessageSerializerChain) serializeKey(key []byte, flags Flags) ([]byte, error) {
 	for _, s := range serializer.serializers {
-		canSerialize, err := s.CanSerialize(serializer.topic)
+		canSerialize, err := s.CanSerializeKey(serializer.topic)
 		if err != nil {
-			return false, err
+			return nil, err
 		}
 
-		if canSerialize {
-			return true, nil
+		if !canSerialize {
+			continue
 		}
+		decodedKey, err := decodeBytes(key, flags.KeyEncoding)
+		if err != nil {
+			return nil, err
+		}
+
+		return s.SerializeKey(decodedKey, flags)
 	}
 
-	return false, nil
+	return nil, errors.Errorf("can't find suitable serializer")
 }

--- a/internal/producer/ProtobufMessageSerializer.go
+++ b/internal/producer/ProtobufMessageSerializer.go
@@ -34,11 +34,11 @@ func CreateProtobufMessageSerializer(topic string, context internal.ProtobufConf
 	}, nil
 }
 
-func (serializer ProtobufMessageSerializer) CanSerializeValue(topic string) (bool, error) {
+func (serializer ProtobufMessageSerializer) CanSerializeValue(_ string) (bool, error) {
 	return serializer.valueDescriptor != nil, nil
 }
 
-func (serializer ProtobufMessageSerializer) CanSerializeKey(topic string) (bool, error) {
+func (serializer ProtobufMessageSerializer) CanSerializeKey(_ string) (bool, error) {
 	return serializer.keyDescriptor != nil, nil
 }
 

--- a/internal/producer/ProtobufMessageSerializer.go
+++ b/internal/producer/ProtobufMessageSerializer.go
@@ -2,6 +2,7 @@ package producer
 
 import (
 	"github.com/IBM/sarama"
+	"github.com/deviceinsight/kafkactl/v5/internal"
 	"github.com/deviceinsight/kafkactl/v5/internal/helpers/protobuf"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/jhump/protoreflect/desc"
@@ -15,7 +16,7 @@ type ProtobufMessageSerializer struct {
 	valueDescriptor *desc.MessageDescriptor
 }
 
-func CreateProtobufMessageSerializer(topic string, context protobuf.SearchContext, keyType, valueType string) (*ProtobufMessageSerializer, error) {
+func CreateProtobufMessageSerializer(topic string, context internal.ProtobufConfig, keyType, valueType string) (*ProtobufMessageSerializer, error) {
 	valueDescriptor := protobuf.ResolveMessageType(context, valueType)
 	if valueDescriptor == nil && valueType != "" {
 		return nil, errors.Errorf("value message type %q not found in provided files", valueType)
@@ -33,39 +34,23 @@ func CreateProtobufMessageSerializer(topic string, context protobuf.SearchContex
 	}, nil
 }
 
-func (serializer ProtobufMessageSerializer) CanSerialize(string) (bool, error) {
-	return true, nil
+func (serializer ProtobufMessageSerializer) CanSerializeValue(topic string) (bool, error) {
+	return serializer.valueDescriptor != nil, nil
 }
 
-func (serializer ProtobufMessageSerializer) Serialize(key, value []byte, flags Flags) (*sarama.ProducerMessage, error) {
-	recordHeaders, err := createRecordHeaders(flags)
-	if err != nil {
-		return nil, err
-	}
-
-	message := &sarama.ProducerMessage{Topic: serializer.topic, Partition: flags.Partition, Headers: recordHeaders}
-
-	if key != nil {
-		message.Key, err = encodeProtobuf(key, serializer.keyDescriptor, flags.KeyEncoding)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	message.Value, err = encodeProtobuf(value, serializer.valueDescriptor, flags.ValueEncoding)
-	if err != nil {
-		return nil, err
-	}
-
-	return message, nil
+func (serializer ProtobufMessageSerializer) CanSerializeKey(topic string) (bool, error) {
+	return serializer.keyDescriptor != nil, nil
 }
 
-func encodeProtobuf(data []byte, messageDescriptor *desc.MessageDescriptor, encoding string) (sarama.ByteEncoder, error) {
-	data, err := decodeBytes(data, encoding)
-	if err != nil {
-		return nil, err
-	}
+func (serializer ProtobufMessageSerializer) SerializeValue(value []byte, _ Flags) ([]byte, error) {
+	return encodeProtobuf(value, serializer.valueDescriptor)
+}
 
+func (serializer ProtobufMessageSerializer) SerializeKey(key []byte, _ Flags) ([]byte, error) {
+	return encodeProtobuf(key, serializer.keyDescriptor)
+}
+
+func encodeProtobuf(data []byte, messageDescriptor *desc.MessageDescriptor) (sarama.ByteEncoder, error) {
 	if messageDescriptor == nil {
 		return data, nil
 	}
@@ -75,7 +60,7 @@ func encodeProtobuf(data []byte, messageDescriptor *desc.MessageDescriptor, enco
 	// can probably be replaced by:
 	// umar := protojson.UnmarshalOptions{DiscardUnknown: true}
 
-	if err = message.UnmarshalJSONPB(&jsonpb.Unmarshaler{AllowUnknownFields: true}, data); err != nil {
+	if err := message.UnmarshalJSONPB(&jsonpb.Unmarshaler{AllowUnknownFields: true}, data); err != nil {
 		return nil, errors.Wrap(err, "invalid json")
 	}
 

--- a/internal/producer/RegistryProtobufMessageSerializer.go
+++ b/internal/producer/RegistryProtobufMessageSerializer.go
@@ -1,0 +1,95 @@
+package producer
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/deviceinsight/kafkactl/v5/internal"
+	"github.com/deviceinsight/kafkactl/v5/internal/helpers/protobuf"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/jhump/protoreflect/dynamic"
+	"github.com/pkg/errors"
+	"github.com/riferrei/srclient"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+type RegistryProtobufMessageSerializer struct {
+	topic  string
+	client *internal.CachingSchemaRegistry
+}
+
+func (serializer RegistryProtobufMessageSerializer) CanSerializeValue(topic string) (bool, error) {
+	return serializer.client.SubjectOfTypeExists(topic+"-value", srclient.Protobuf)
+}
+
+func (serializer RegistryProtobufMessageSerializer) CanSerializeKey(topic string) (bool, error) {
+	return serializer.client.SubjectOfTypeExists(topic+"-key", srclient.Protobuf)
+}
+
+func (serializer RegistryProtobufMessageSerializer) SerializeValue(value []byte, flags Flags) ([]byte, error) {
+	return serializer.encode(value, flags.ValueSchemaVersion, flags.ValueProtoType, serializer.topic+"-value")
+}
+
+func (serializer RegistryProtobufMessageSerializer) SerializeKey(key []byte, flags Flags) ([]byte, error) {
+	return serializer.encode(key, flags.KeySchemaVersion, flags.KeyProtoType, serializer.topic+"-key")
+}
+
+func (serializer RegistryProtobufMessageSerializer) encode(rawData []byte, schemaVersion int, msgName string, subject string) ([]byte, error) {
+	var schema *srclient.Schema
+	var err error
+
+	if schemaVersion == -1 {
+		schema, err = serializer.client.GetLatestSchema(subject)
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("couldn't get schema for subject %s", subject))
+		}
+	} else {
+		schema, err = serializer.client.GetSchema(schemaVersion)
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("couldn't get schema for schemaId %d", schemaVersion))
+		}
+	}
+
+	fileDesc, err := protobuf.SchemaToFileDescriptor(serializer.client, schema)
+	if err != nil {
+		return nil, err
+	}
+
+	messageDesc := fileDesc.FindMessage(msgName)
+	if messageDesc == nil {
+		messageDesc = fileDesc.GetMessageTypes()[0]
+		msgName = messageDesc.GetFullyQualifiedName()
+	}
+
+	dynmsg := dynamicpb.NewMessage(messageDesc.UnwrapMessage())
+	_ = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(rawData, dynmsg)
+	message := dynamic.NewMessage(messageDesc)
+
+	if err := message.UnmarshalJSONPB(&jsonpb.Unmarshaler{AllowUnknownFields: true}, rawData); err != nil {
+		return nil, errors.Wrap(err, "invalid json")
+	}
+
+	pb, err := message.Marshal()
+	if err != nil {
+		return nil, err
+	}
+
+	result := []byte{internal.MagicByte}
+	result = binary.BigEndian.AppendUint32(result, uint32(schema.ID()))
+	indexes, err := protobuf.ComputeIndexes(fileDesc, msgName)
+	if err != nil {
+		return nil, err
+	}
+
+	result = binary.AppendVarint(result, int64(len(indexes)))
+	if len(indexes) != 0 {
+		for _, idx := range indexes {
+			result = binary.AppendVarint(result, idx)
+		}
+	}
+
+	result = append(result, pb...)
+
+	return result, nil
+}

--- a/internal/producer/producer-operation.go
+++ b/internal/producer/producer-operation.go
@@ -45,11 +45,9 @@ type Flags struct {
 
 const DefaultMaxMessagesBytes = 1000000
 
-type Operation struct {
-}
+type Operation struct{}
 
 func (operation *Operation) Produce(topic string, flags Flags) error {
-
 	var (
 		clientContext internal.ClientContext
 		err           error
@@ -84,16 +82,17 @@ func (operation *Operation) Produce(topic string, flags Flags) error {
 		if err != nil {
 			return err
 		}
-		serializer := AvroMessageSerializer{topic: topic, client: client, jsonCodec: clientContext.Avro.JSONCodec}
+		avroSerializer := AvroMessageSerializer{topic: topic, client: client, jsonCodec: clientContext.Avro.JSONCodec}
+		protobufSerializer := RegistryProtobufMessageSerializer{topic: topic, client: client}
 
-		serializers.serializers = append(serializers.serializers, serializer)
+		serializers.serializers = append(serializers.serializers, avroSerializer, protobufSerializer)
 	}
+	context := clientContext.Protobuf
+	context.ProtosetFiles = append(flags.ProtosetFiles, context.ProtosetFiles...)
+	context.ProtoFiles = append(flags.ProtoFiles, context.ProtoFiles...)
+	context.ProtoImportPaths = append(flags.ProtoImportPaths, context.ProtoImportPaths...)
 
-	if flags.KeyProtoType != "" || flags.ValueProtoType != "" {
-		context := clientContext.Protobuf
-		context.ProtosetFiles = append(flags.ProtosetFiles, context.ProtosetFiles...)
-		context.ProtoFiles = append(flags.ProtoFiles, context.ProtoFiles...)
-		context.ProtoImportPaths = append(flags.ProtoImportPaths, context.ProtoImportPaths...)
+	if len(context.ProtoFiles) != 0 || len(context.ProtoImportPaths) != 0 || len(context.ProtosetFiles) != 0 {
 
 		serializer, err := CreateProtobufMessageSerializer(topic, context, flags.KeyProtoType, flags.ValueProtoType)
 		if err != nil {
@@ -244,7 +243,6 @@ func (operation *Operation) Produce(topic string, flags Flags) error {
 }
 
 func applyProducerConfigs(config *sarama.Config, clientContext internal.ClientContext, flags Flags) error {
-
 	var err error
 
 	partitioner := clientContext.Producer.Partitioner
@@ -327,9 +325,7 @@ func stdinAvailable() bool {
 }
 
 func splitAt(delimiter string) func(data []byte, atEOF bool) (advance int, token []byte, err error) {
-
 	return func(data []byte, atEOF bool) (advance int, token []byte, err error) {
-
 		// Return nothing if at end of file and no data passed
 		if atEOF && len(data) == 0 {
 			return 0, nil, nil

--- a/internal/testutil/test_util.go
+++ b/internal/testutil/test_util.go
@@ -84,6 +84,11 @@ func StartIntegrationTest(t *testing.T) {
 }
 
 func StartIntegrationTestWithContext(t *testing.T, context string) {
+
+	if !strings.HasSuffix(t.Name(), "Integration") {
+		t.Fatalf("integration tests have to be suffixed with 'Integration' to ensure they are executed")
+	}
+
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -172,13 +177,14 @@ func startTest(t *testing.T, logFilename string) {
 }
 
 func AssertEquals(t *testing.T, expected, actual string) {
-
+	t.Helper()
 	if strings.TrimSpace(actual) != strings.TrimSpace(expected) {
 		t.Fatalf("unexpected output:\nexpected:\n--\n%s\n--\nactual:\n--\n%s\n--", expected, strings.TrimSpace(actual))
 	}
 }
 
 func AssertArraysEquals(t *testing.T, expected, actual []string) {
+	t.Helper()
 	sort.Strings(expected)
 	sort.Strings(actual)
 
@@ -188,7 +194,7 @@ func AssertArraysEquals(t *testing.T, expected, actual []string) {
 }
 
 func AssertErrorContainsOneOf(t *testing.T, expected []string, err error) {
-
+	t.Helper()
 	if err == nil {
 		t.Fatalf("expected error to contain: %s\n: %v", expected, "nil")
 	}
@@ -203,7 +209,7 @@ func AssertErrorContainsOneOf(t *testing.T, expected []string, err error) {
 }
 
 func AssertErrorContains(t *testing.T, expected string, err error) {
-
+	t.Helper()
 	if err == nil {
 		t.Fatalf("expected error to contain: %s\n: %v", expected, "nil")
 	}
@@ -214,12 +220,14 @@ func AssertErrorContains(t *testing.T, expected string, err error) {
 }
 
 func AssertContainSubstring(t *testing.T, expected, actual string) {
+	t.Helper()
 	if !strings.Contains(actual, expected) {
 		t.Fatalf("expected string to contain: %s actual: %s", expected, actual)
 	}
 }
 
 func AssertContains(t *testing.T, expected string, array []string) {
+	t.Helper()
 	if !util.ContainsString(array, expected) {
 		t.Fatalf("expected array to contain: %s\narray: %v", expected, array)
 	}


### PR DESCRIPTION
# Description

This includes support for serializing and deserializing protobuf messages by fetching schemas from schema registry

Fixes #232

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [X] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.adoc` was updated
- [ ] a usage example was added to `README.adoc`
- [X] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
