### PR TITLE
Resolve whole references tree

### DIFF
--- a/cmd/consume/consume_test.go
+++ b/cmd/consume/consume_test.go
@@ -150,7 +150,9 @@ func TestConsumeFromTimestampIntegration(t *testing.T) {
 	testutil.AssertArraysEquals(t, []string{"g", "h"}, messages)
 }
 
-func TestConsumeRegistryProtobufWithNestedDependencies(t *testing.T) {
+func TestConsumeRegistryProtobufWithNestedDependenciesIntegration(t *testing.T) {
+	testutil.StartIntegrationTest(t)
+
 	bazMsg := `syntax = "proto3";
   package baz;
 
@@ -172,13 +174,13 @@ func TestConsumeRegistryProtobufWithNestedDependencies(t *testing.T) {
 	fooMsg := `syntax = "proto3";
   package foo;
 
-  import "bar/protobuf/bar.proto"
+  import "bar/protobuf/bar.proto";
 
   message Foo {
     bar.Bar barField = 1;
   }`
 
-	value := `{"barField":{"bazField":{"field": "value"}}}`
+	value := `{"barField":{"bazField":{"field":"value"}}}`
 
 	testutil.RegisterSchema(t, "baz", bazMsg, srclient.Protobuf)
 	testutil.RegisterSchema(t, "bar", barMsg, srclient.Protobuf, srclient.Reference{Name: "baz/protobuf/baz.proto", Version: 1, Subject: "baz"})

--- a/cmd/consume/consume_test.go
+++ b/cmd/consume/consume_test.go
@@ -2,6 +2,7 @@ package consume_test
 
 import (
 	"encoding/hex"
+	"fmt"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -147,6 +148,54 @@ func TestConsumeFromTimestampIntegration(t *testing.T) {
 	}
 	messages = strings.Split(strings.TrimSpace(kafkaCtl.GetStdOut()), "\n")
 	testutil.AssertArraysEquals(t, []string{"g", "h"}, messages)
+}
+
+func TestConsumeRegistryProtobufWithNestedDependencies(t *testing.T) {
+	bazMsg := `syntax = "proto3";
+  package baz;
+
+  message Baz {
+    string field = 1;
+  }
+  `
+
+	barMsg := `syntax = "proto3";
+  package bar;
+
+  import "baz/protobuf/baz.proto";
+
+  message Bar {
+    baz.Baz bazField = 1;
+  }
+  `
+
+	fooMsg := `syntax = "proto3";
+  package foo;
+
+  import "bar/protobuf/bar.proto"
+
+  message Foo {
+    bar.Bar barField = 1;
+  }`
+
+	value := `{"barField":{"bazField":{"field": "value"}}}`
+
+	testutil.RegisterSchema(t, "baz", bazMsg, srclient.Protobuf)
+	testutil.RegisterSchema(t, "bar", barMsg, srclient.Protobuf, srclient.Reference{Name: "baz/protobuf/baz.proto", Version: 1, Subject: "baz"})
+	topicName := testutil.CreateTopic(t, "consume-topic")
+	testutil.RegisterSchema(t, topicName+"-value", fooMsg, srclient.Protobuf, srclient.Reference{Name: "bar/protobuf/bar.proto", Version: 1, Subject: "bar"})
+
+	kafkaCtl := testutil.CreateKafkaCtlCommand()
+	if _, err := kafkaCtl.Execute("produce", topicName, "--key", "test-key", "--value", value); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+	testutil.AssertEquals(t, "message produced (partition=0\toffset=0)", kafkaCtl.GetStdOut())
+
+	if _, err := kafkaCtl.Execute("consume", topicName, "--from-beginning", "--exit", "--print-keys"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	testutil.AssertEquals(t, fmt.Sprintf("test-key#%s", value), kafkaCtl.GetStdOut())
 }
 
 func TestConsumeToTimestampIntegration(t *testing.T) {

--- a/internal/consume/RegistryProtobufMessageDeserializer.go
+++ b/internal/consume/RegistryProtobufMessageDeserializer.go
@@ -153,7 +153,7 @@ func (deserializer RegistryProtobufMessageDeserializer) resolveDependencies(reso
 		if _, ok := resolved[r.Name]; ok {
 			continue
 		}
-		latest, err := deserializer.registry.GetLatestSchema(r.Subject)
+		latest, err := deserializer.registry.GetSchemaByVersion(r.Subject, r.Version)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Instead of just 1 level of references it's going
to download all levels.
Also use Name instead of Subject as a reference filename

I don't know what I was thinking with this resolve not going deeper initially.

And about the Subject -> Name change. Here's the part from the Confluent [documentation](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#schema-references):

>A schema reference consists of the following:
    * A name for the reference. (For Avro, the reference name is the fully qualified schema name, for JSON Schema it is a URL, and for Protobuf, it is the name of another Protobuf file.)
    * A subject, representing the subject under which the referenced schema is registered.
    * A version, representing the exact version of the schema under the registered subject.


I made a mistake and used just wrong thing

# Description

Please include a summary of the change and which issue is fixed.
List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [ ] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.adoc` was updated
- [ ] a usage example was added to `README.adoc`
- [ ] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
