### PR TITLE
consumer: adds options for protobuf output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [#251](https://github.com/deviceinsight/kafkactl/pull/251) Adds `--proto-use-field-names` and `--proto-use-enum-numbers`
+  flags to `consume` command, allowing more control over the ProtoJSON output.
+
 ## 5.7.0 - 2025-04-02
 
 ### Added

--- a/cmd/consume/consume.go
+++ b/cmd/consume/consume.go
@@ -49,6 +49,8 @@ func NewConsumeCmd() *cobra.Command {
 	cmdConsume.Flags().StringVarP(&flags.KeyProtoType, "key-proto-type", "", flags.KeyProtoType, "key protobuf message type")
 	cmdConsume.Flags().StringVarP(&flags.ValueProtoType, "value-proto-type", "", flags.ValueProtoType, "value protobuf message type")
 	cmdConsume.Flags().StringVarP(&flags.IsolationLevel, "isolation-level", "i", "", "isolationLevel to use. One of: ReadUncommitted|ReadCommitted")
+	cmdConsume.Flags().BoolVar(&flags.ProtoUseFieldNames, "proto-use-field-names", false, "output protobuf JSON with field names rather than normalized lowerCamelCase")
+	cmdConsume.Flags().BoolVar(&flags.ProtoUseEnumNumbers, "proto-use-enum-numbers", false, "output protobuf enums as numeric values rather than names")
 
 	if err := cmdConsume.RegisterFlagCompletionFunc("group", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return consumergroups.CompleteConsumerGroups(cmd, args, toComplete)

--- a/cmd/consume/consume_test.go
+++ b/cmd/consume/consume_test.go
@@ -348,11 +348,11 @@ func TestProtobufConsumeProtoFileIntegration(t *testing.T) {
 
 	testutil.AssertEquals(t, "message produced (partition=0\toffset=0)", kafkaCtl.GetStdOut())
 
-	if _, err := kafkaCtl.Execute("consume", pbTopic, "--from-beginning", "--exit", "--proto-import-path", protoPath, "--proto-file", "msg.proto", "--value-proto-type", "TopicMessage"); err != nil {
+	if _, err := kafkaCtl.Execute("consume", pbTopic, "--from-beginning", "--exit", "--proto-import-path", protoPath, "--proto-file", "msg.proto", "--value-proto-type", "TopicMessage", "--proto-use-field-names"); err != nil {
 		t.Fatalf("failed to execute command: %v", err)
 	}
 
-	testutil.AssertEquals(t, `{"producedAt":"2021-12-01T14:10:12Z","num":"1"}`, kafkaCtl.GetStdOut())
+	testutil.AssertEquals(t, `{"produced_at":"2021-12-01T14:10:12Z","num":"1"}`, kafkaCtl.GetStdOut())
 }
 
 func TestProtobufConsumeProtoFileWithoutProtoImportPathIntegration(t *testing.T) {

--- a/internal/consume/consume-operation.go
+++ b/internal/consume/consume-operation.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/deviceinsight/kafkactl/v5/internal/helpers"
+	"github.com/golang/protobuf/jsonpb"
 
 	"golang.org/x/sync/errgroup"
 
@@ -41,6 +42,9 @@ type Flags struct {
 	KeyProtoType     string
 	ValueProtoType   string
 	IsolationLevel   string
+
+	ProtoUseFieldNames  bool
+	ProtoUseEnumNumbers bool
 }
 
 type ConsumedMessage struct {
@@ -108,7 +112,11 @@ func (operation *Operation) Consume(topic string, flags Flags) error {
 	searchCtx.ProtoFiles = append(flags.ProtoFiles, searchCtx.ProtoFiles...)
 	searchCtx.ProtoImportPaths = append(flags.ProtoImportPaths, searchCtx.ProtoImportPaths...)
 
-	deserializer, err := CreateProtobufMessageDeserializer(searchCtx, flags.KeyProtoType, flags.ValueProtoType)
+	jsonMarshaler := &jsonpb.Marshaler{
+		OrigName:    flags.ProtoUseFieldNames,
+		EnumsAsInts: flags.ProtoUseEnumNumbers,
+	}
+	deserializer, err := CreateProtobufMessageDeserializer(searchCtx, flags.KeyProtoType, flags.ValueProtoType, jsonMarshaler)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

# Description

By default the ProtoJSON encoder emits normalizes field names to lowerCamelCase and emits enums as string values per the [spec](https://protobuf.dev/programming-guides/json/), however there are cases where one might want to preserve the original field names or see the ordinal values of enums.

To that end, this diff adds two flags to the `consume` subcommand:

* The `--proto-use-field-names` flag configures the ProtoJSON decoder to output protobufs using their field names.
* The `--proto-use-enum-numbers` flag configures the ProtoJSON decoder to output protobuf enums using their numeric values rather than variant names.

Thoughts
1. I picked flag names that seemed intuitive to me, but I'm happy to change them!
2. While I tested it locally, I did not add an integration test for `--proto-use-enum-numbers` as it would have been more invasive (our test fixture lacks an enum field) and that flag is pretty straight forward. That said I'm happy to add one if desired.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Documentation

- [X] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.adoc` was updated
- [ ] a usage example was added to `README.adoc`
- [X] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
