### PR TITLE
Set resource name when creating a cluster ACL

### DIFF
--- a/cmd/create/create-acl_test.go
+++ b/cmd/create/create-acl_test.go
@@ -107,3 +107,15 @@ func TestCreateTopicAlterConfigsDenyAclIntegration(t *testing.T) {
 
 	testutil.AssertErrorContainsOneOf(t, []string{pre27ErrorMessage, errorMessage}, err)
 }
+
+func TestCreateClusterIdempotentWriteAllowAclIntegration(t *testing.T) {
+		testutil.StartIntegrationTestWithContext(t, "sasl-admin")
+
+	kafkaCtl := testutil.CreateKafkaCtlCommand()
+
+	// add cluster acl
+	kafkaCtl = testutil.CreateKafkaCtlCommand()
+	if _, err := kafkaCtl.Execute("create", "acl", "--cluster", "--operation", "IdempotentWrite", "--allow", "--principal", "User:user"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+}

--- a/internal/acl/acl-operation.go
+++ b/internal/acl/acl-operation.go
@@ -195,6 +195,7 @@ func (operation *Operation) CreateACL(flags CreateACLFlags) error {
 		resource.ResourcePatternType = patternTypeFromString(flags.PatternType)
 	} else {
 		resource.ResourceType = sarama.AclResourceCluster
+		resource.ResourceName = "kafka-cluster"
 		resource.ResourcePatternType = patternTypeFromString(flags.PatternType)
 	}
 


### PR DESCRIPTION
# Description

Brokers running 3.9.0 will reject a cluster ACL unless the resource name is set to kafka-cluster

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Documentation

- [ ] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [x] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
