### PR TITLE
fix: update SASL options serialization in kubernetes mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- SASL token provider plugin options are now working in kubernetes mode.
+
 ## 5.8.0 - 2025-05-16
 
 ## 5.7.0 - 2025-04-02

--- a/internal/k8s/k8s-operation.go
+++ b/internal/k8s/k8s-operation.go
@@ -246,7 +246,7 @@ func appendMapIfDefined(env []string, key string, value map[string]any) []string
 		if err != nil {
 			panic(err)
 		}
-		return append(env, fmt.Sprintf("%s=%q", key, jsonMap))
+		return append(env, fmt.Sprintf("%s=%s", key, jsonMap))
 	}
 	return env
 }

--- a/internal/k8s/k8s-operation_test.go
+++ b/internal/k8s/k8s-operation_test.go
@@ -79,7 +79,7 @@ func TestAllAvailableEnvironmentVariablesAreParsed(t *testing.T) {
 	testutil.AssertEquals(t, "pass", envMap[global.SaslPassword])
 	testutil.AssertEquals(t, "oauth", envMap[global.SaslMechanism])
 	testutil.AssertEquals(t, "azure", envMap[global.SaslTokenProviderPlugin])
-	testutil.AssertEquals(t, `"{\"int-key\":12,\"tenantid\":\"azure-tenant-id\"}"`, envMap[global.SaslTokenProviderOptions])
+	testutil.AssertEquals(t, `{"int-key":12,"tenantid":"azure-tenant-id"}`, envMap[global.SaslTokenProviderOptions])
 	testutil.AssertEquals(t, "my-client", envMap[global.ClientID])
 	testutil.AssertEquals(t, "2.0.1", envMap[global.KafkaVersion])
 	testutil.AssertEquals(t, "avro", envMap[global.AvroJSONCodec])


### PR DESCRIPTION
# Description

The SASL_TOKENPROVIDER_OPTIONS value was serialized as a quoted string. This caused it to be ignored by the kafkactl instance running on container in the K8S cluster.

Before:
```
Environment:
  BROKERS:                        xxx.servicebus.windows.net:9093
  TLS_ENABLED:                    true
  SASL_ENABLED:                   true
  SASL_MECHANISM:                 oauth
  SASL_TOKENPROVIDER_PLUGIN:      azure
  SASL_TOKENPROVIDER_OPTIONS:     "{\"az-events\":\"Request,Response\",\"client-id\":\"xxx\",\"tenant-id\":\"xxx\",\"verbose\":true}"
[...]
```

After:
```
Environment:
  BROKERS:                        xxx.servicebus.windows.net:9093
  TLS_ENABLED:                    true
  SASL_ENABLED:                   true
  SASL_MECHANISM:                 oauth
  SASL_TOKENPROVIDER_PLUGIN:      azure
  SASL_TOKENPROVIDER_OPTIONS:     {"az-events":"Request,Response","client-id":"xxx","tenant-id":"xxx","verbose":true}
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [x] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
