### PR TITLE
Fix computation of startOffset for partition when using tail

### DIFF
--- a/internal/consume/PartitionConsumer.go
+++ b/internal/consume/PartitionConsumer.go
@@ -151,12 +151,12 @@ func getOffsetBounds(client *sarama.Client, topic string, flags Flags, currentPa
 		endOffset = endOffset - 1
 	}
 	if flags.Tail > 0 && startOffset == sarama.OffsetNewest {
-		//When --tail is used compute startOffset so that it minimizes the number of messages consumed
-		if endOffset-int64(flags.Tail) > 0 {
-			startOffset = endOffset - int64(flags.Tail)
-		} else {
-			startOffset = sarama.OffsetOldest
+		// When --tail is used compute startOffset so that it minimizes the number of messages consumed
+		var oldestOffset int64
+		if oldestOffset, err = (*client).GetOffset(topic, currentPartition, sarama.OffsetOldest); err != nil {
+			return ErrOffset, ErrOffset, err
 		}
+		startOffset = max(oldestOffset, endOffset-int64(flags.Tail))
 	}
 	output.Debugf("consumer will consume offset %d to %d on partition %d", startOffset, endOffset, currentPartition)
 	return startOffset, endOffset, nil


### PR DESCRIPTION
Fixes #154

# Description

The calculation of the start offset when tailing based on 0 doesn't make much sense in case of sparse topics that lived some time already. When setting tail to 10, and having a topic that already is at offset 900 will get the startOffset 890.
The current offset 900 doesn't necessarily mean that there are 900 messages available now. It still might be 0 messages.
That's why I think better way to do it is to obtain the current oldest offset and choose greater of the two.


Fixes #154

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [ ] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.adoc` was updated
- [ ] a usage example was added to `README.adoc`
- [ ] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
