### PR TITLE
Add wellknowntypes to source resolver for protocompile

### DIFF
--- a/cmd/consume/consume_test.go
+++ b/cmd/consume/consume_test.go
@@ -203,7 +203,7 @@ func TestConsumeRegistryProtobufWithNestedDependenciesIntegration(t *testing.T) 
 	testutil.AssertEquals(t, fmt.Sprintf("test-key#%s", value), kafkaCtl.GetStdOut())
 }
 
-func TestConsumeRegistryProtobufWithWellKnowType(t *testing.T) {
+func TestConsumeRegistryProtobufWithWellKnowTypeIntegration(t *testing.T) {
 	testutil.StartIntegrationTest(t)
 
 	bazMsg := `syntax = "proto3";

--- a/cmd/consume/consume_test.go
+++ b/cmd/consume/consume_test.go
@@ -206,18 +206,18 @@ func TestConsumeRegistryProtobufWithNestedDependenciesIntegration(t *testing.T) 
 func TestConsumeRegistryProtobufWithWellKnowTypeIntegration(t *testing.T) {
 	testutil.StartIntegrationTest(t)
 
-	bazMsg := `syntax = "proto3";
-  package baz;
+	newFooMsg := `syntax = "proto3";
+  package new.foo;
 
   import "google/protobuf/timestamp.proto";
 
-  message Baz {
+  message Foo {
     google.protobuf.Timestamp field = 1;
   }
   `
 	value := `{"field":"2025-06-07T11:11:11Z"}`
 
-	testutil.RegisterSchema(t, "baz", bazMsg, srclient.Protobuf)
+	testutil.RegisterSchema(t, "new.foo", newFooMsg, srclient.Protobuf)
 	topicName := testutil.CreateTopic(t, "consume-topic")
 
 	kafkaCtl := testutil.CreateKafkaCtlCommand()

--- a/internal/helpers/protobuf/protobuf.go
+++ b/internal/helpers/protobuf/protobuf.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/protobuf/reflect/protodesc"
 
 	"github.com/bufbuild/protocompile"
-	"github.com/bufbuild/protocompile/wellknownimports"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"google.golang.org/protobuf/proto"
@@ -64,7 +63,7 @@ func ParseFileDescriptor(filename string, resolvedSchemas map[string]string) (pr
 	resolver := protocompile.SourceResolver{Accessor: protocompile.SourceAccessorFromMap(resolvedSchemas)}
 
 	compiler := protocompile.Compiler{
-		Resolver: wellknownimports.WithStandardImports(&resolver),
+		Resolver: protocompile.WithStandardImports(&resolver),
 	}
 
 	parsedFiles, err := compiler.Compile(context.Background(), filename)

--- a/internal/helpers/protobuf/protobuf.go
+++ b/internal/helpers/protobuf/protobuf.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/protobuf/reflect/protodesc"
 
 	"github.com/bufbuild/protocompile"
+	"github.com/bufbuild/protocompile/wellknownimports"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"google.golang.org/protobuf/proto"
@@ -63,7 +64,7 @@ func ParseFileDescriptor(filename string, resolvedSchemas map[string]string) (pr
 	resolver := protocompile.SourceResolver{Accessor: protocompile.SourceAccessorFromMap(resolvedSchemas)}
 
 	compiler := protocompile.Compiler{
-		Resolver: &resolver,
+		Resolver: wellknownimports.WithStandardImports(&resolver),
 	}
 
 	parsedFiles, err := compiler.Compile(context.Background(), filename)
@@ -109,7 +110,6 @@ func FindMessageDescriptor(fileDesc protoreflect.FileDescriptor, msgName protore
 }
 
 func findMessageDescriptor(messages protoreflect.MessageDescriptors, msgName protoreflect.FullName) (protoreflect.MessageDescriptor, error) {
-
 	for i := range messages.Len() {
 		message := messages.Get(i)
 
@@ -174,7 +174,6 @@ func makeDescriptors(protobufConfig internal.ProtobufConfig) []protoreflect.File
 }
 
 func readFileDescriptors(protoSetFiles []string) []protoreflect.FileDescriptor {
-
 	var descriptors []protoreflect.FileDescriptor
 
 	for _, protoSetFile := range protoSetFiles {


### PR DESCRIPTION
# Description

It includes standard types to protocompile, so user can have in his proto file  `import "google/protobuf/*.proto` and it'll just work

Fixes #258 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [ ] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.adoc` was updated
- [ ] a usage example was added to `README.adoc`
- [x] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
