### PR TITLE
Pass --tty only for attach

### DIFF
--- a/internal/k8s/executor.go
+++ b/internal/k8s/executor.go
@@ -44,7 +44,6 @@ type executor struct {
 const letterBytes = "abcdefghijklmnpqrstuvwxyz123456789"
 
 func randomString(n int) string {
-
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	b := make([]byte, n)
@@ -55,7 +54,6 @@ func randomString(n int) string {
 }
 
 func getKubectlVersion(kubectlBinary string, runner Runner) (Version, error) {
-
 	bytes, err := runner.ExecuteAndReturn(kubectlBinary, []string{"version", "--client", "-o", "json"})
 	if err != nil {
 		return Version{}, err
@@ -97,7 +95,6 @@ func getKubectlVersion(kubectlBinary string, runner Runner) (Version, error) {
 }
 
 func newExecutor(context internal.ClientContext, runner Runner) (*executor, error) {
-
 	version, err := getKubectlVersion(context.Kubernetes.Binary, runner)
 	if err != nil {
 		return nil, err
@@ -127,16 +124,17 @@ func (kubectl *executor) SetKubectlBinary(bin string) {
 	kubectl.kubectlBinary = bin
 }
 
-func (kubectl *executor) Run(dockerImageType, entryPoint string, kafkactlArgs []string, podEnvironment []string) error {
-
+func (kubectl *executor) Run(dockerImageType, entryPoint string, kafkactlArgs []string, podEnvironment []string, additionalKubectlArgs ...string) error {
 	dockerImage := getDockerImage(kubectl.image, dockerImageType)
 
 	podName := fmt.Sprintf("kafkactl-%s-%s", strings.ToLower(kubectl.clientID), randomString(4))
 
 	kubectlArgs := []string{
-		"run", "-i", "--tty", "--restart=Never", podName,
+		"run", "-i", "--restart=Never", podName,
 		"--image", dockerImage,
 	}
+
+	kubectlArgs = append(kubectlArgs, additionalKubectlArgs...)
 
 	if !kubectl.keepPod {
 		kubectlArgs = slices.Insert(kubectlArgs, 1, "--rm")
@@ -177,7 +175,6 @@ func (kubectl *executor) Run(dockerImageType, entryPoint string, kafkactlArgs []
 }
 
 func addTerminalSizeEnv(args []string) []string {
-
 	if !term.IsTerminal(0) {
 		output.Debugf("no terminal detected")
 		return args
@@ -195,7 +192,6 @@ func addTerminalSizeEnv(args []string) []string {
 }
 
 func getDockerImage(image string, imageType string) string {
-
 	if KafkaCtlVersion == "" {
 		KafkaCtlVersion = "latest"
 	}

--- a/internal/k8s/k8s-operation.go
+++ b/internal/k8s/k8s-operation.go
@@ -31,7 +31,6 @@ func NewOperation() Operation {
 }
 
 func (op *operation) initialize(context internal.ClientContext) error {
-
 	if !context.Kubernetes.Enabled {
 		return errors.Errorf("context is not a kubernetes context: %s", context.Name)
 	}
@@ -48,7 +47,6 @@ func (op *operation) initialize(context internal.ClientContext) error {
 }
 
 func (op *operation) Attach() error {
-
 	context, err := internal.CreateClientContext()
 	if err != nil {
 		return err
@@ -65,11 +63,10 @@ func (op *operation) Attach() error {
 
 	podEnvironment := parsePodEnvironment(context)
 
-	return exec.Run("ubuntu", "bash", nil, podEnvironment)
+	return exec.Run("ubuntu", "bash", nil, podEnvironment, "--tty")
 }
 
 func (op *operation) Run(cmd *cobra.Command, args []string) error {
-
 	context, err := internal.CreateClientContext()
 	if err != nil {
 		return err
@@ -83,7 +80,6 @@ func (op *operation) Run(cmd *cobra.Command, args []string) error {
 }
 
 func (op *operation) run(context internal.ClientContext, cmd *cobra.Command, args []string) error {
-
 	if err := op.initialize(context); err != nil {
 		return err
 	}
@@ -174,7 +170,6 @@ func parseCompleteCommand(cmd *cobra.Command, found []string) []string {
 }
 
 func parsePodEnvironment(context internal.ClientContext) []string {
-
 	var envVariables []string
 
 	envVariables = appendStrings(envVariables, global.Brokers, context.Brokers)


### PR DESCRIPTION
# Description

`--tty` option should be passed only for interactive sessions. From what I understand `attach` is the only such option so it's the only one that should use it

Fixes #263 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [ ] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.adoc` was updated
- [ ] a usage example was added to `README.adoc`
- [ ] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
