### PR TITLE
Filter out context option when running through kubectl

### DIFF
--- a/internal/k8s/executor.go
+++ b/internal/k8s/executor.go
@@ -167,7 +167,7 @@ func (kubectl *executor) Run(dockerImageType, entryPoint string, kafkactlArgs []
 
 	// Keep only kafkactl arguments that are relevant in k8s context
 	allExceptConfigFileFilter := func(s string) bool {
-		return !strings.HasPrefix(s, "-C=") && !strings.HasPrefix(s, "--config-file=")
+		return !strings.HasPrefix(s, "-C=") && !strings.HasPrefix(s, "--config-file=") && !strings.HasPrefix(s, "--context=")
 	}
 	kubectlArgs = append(kubectlArgs, filter(kafkactlArgs, allExceptConfigFileFilter)...)
 


### PR DESCRIPTION
# Description

When running kafkactl in k8s the only available context seems to be `default`, and for the most cases this is not the option used for running `kafkactl`, therefore this `context` option should not be passed as an argument to `kafkactl` running inside k8s cluster.

Fixes #266

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [ ] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.adoc` was updated
- [ ] a usage example was added to `README.adoc`
- [ ] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
