### PR TITLE
write current context to separate file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Current context is now stored in a separate file to avoid write operations on the config file.
+
 ### Changed
 - Update to Go 1.24.4
 

--- a/README.adoc
+++ b/README.adoc
@@ -222,9 +222,6 @@ contexts:
     consumer:
       # optional: isolationLevel (defaults to ReadCommitted)
       isolationLevel: ReadUncommitted
-
-# optional for project config files
-current-context: default
 ----
 
 [#_config_file_read_order]
@@ -254,15 +251,6 @@ In order to identify the config file as belonging to _kafkactl_ the following na
 During initialization _kafkactl_ starts from the current working directory and recursively looks for a project level
 config file. The recursive lookup ends at the boundary of a git repository (i.e. if a `.git` folder is found).
 This way, _kafkactl_ can be used conveniently anywhere in the git repository.
-
-Additionally, project config files have a special feature to use them read-only. Topically, if you configure more than
-one context in a config file, and you switch the context with `kafkactl config use-context xy` this will lead to a write
-operation on the config file to save the _current context_.
-
-In order to avoid this for project config files, one can just omit the `current-context` parameter from the config file.
-In this case _kafkactl_ will delegate read and write operations for the _current context_ to the next configuration file
-according to <<_config_file_read_order, the config file read order>>.
-
 
 === Auto completion
 

--- a/cmd/config/view_test.go
+++ b/cmd/config/view_test.go
@@ -20,13 +20,21 @@ func TestViewConfigWithEnvVariablesInGeneratedConfigSet(t *testing.T) {
 	}
 
 	newConfigFile := path.Join(currentDir, "non-existing-config.yml")
+	newContextFile := path.Join(currentDir, "non-existing-context.yml")
 	defer func() {
 		if err = os.Remove(newConfigFile); err != nil {
 			output.TestLogf("unable to delete file %s: %v", newConfigFile, err)
 		}
+		if err = os.Remove(newContextFile); err != nil {
+			output.TestLogf("unable to delete file %s: %v", newContextFile, err)
+		}
 	}()
 
 	if err := os.Setenv("KAFKA_CTL_CONFIG", newConfigFile); err != nil {
+		t.Fatalf("unable to set env variable: %v", err)
+	}
+
+	if err := os.Setenv("KAFKA_CTL_WRITABLE_CONFIG", newContextFile); err != nil {
 		t.Fatalf("unable to set env variable: %v", err)
 	}
 
@@ -39,7 +47,9 @@ func TestViewConfigWithEnvVariablesInGeneratedConfigSet(t *testing.T) {
 	defaultConfigContent := `
 contexts:
     default:
-        brokers: env-broker:9092
+        brokers: env-broker:9092`
+
+	defaultContextContent := `
 current-context: default`
 
 	if _, err := kafkaCtl.Execute("config", "view"); err != nil {
@@ -51,6 +61,12 @@ current-context: default`
 		t.Fatalf("error reading generated config %s %v", newConfigFile, err)
 	}
 
+	contextContent, err := os.ReadFile(newContextFile)
+	if err != nil {
+		t.Fatalf("error reading generated config %s %v", newContextFile, err)
+	}
+
 	testutil.AssertEquals(t, defaultConfigContent, string(configContent))
+	testutil.AssertEquals(t, defaultContextContent, string(contextContent))
 	testutil.AssertEquals(t, defaultConfigContent, kafkaCtl.GetStdOut())
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -24,7 +24,7 @@ func TestEnvironmentVariableLoading(t *testing.T) {
 
 	kafkaCtl := testutil.CreateKafkaCtlCommand()
 
-	if _, err := kafkaCtl.Execute("version"); err != nil {
+	if _, err := kafkaCtl.Execute("config", "current-context"); err != nil {
 		t.Fatalf("failed to execute command: %v", err)
 	}
 

--- a/internal/global/config_test.go
+++ b/internal/global/config_test.go
@@ -59,11 +59,6 @@ func TestResolvePath(t *testing.T) {
 			filename:     "root.go",
 			wantFilename: "cmd/root.go",
 		},
-		{
-			description:  "filename_resolvable_relative_to_writable_config",
-			filename:     "plugins/plugins.go",
-			wantFilename: "pkg/plugins/plugins.go",
-		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
 


### PR DESCRIPTION
# Description

Write current context to separate file in order to use the config.yml readonly.

Fixes #262
Fixes #268 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [x] the configuration yaml was changed and the example config in `README.adoc` was updated
- [ ] a usage example was added to `README.adoc`
- [ ] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
