### PR TITLE
fix panic() when configuring a nil map as tokenProvider.options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update to Go 1.24.4
 
+### Fixed
+- Fixed panic() when configuring a nil map as tokenProvider.options
+
 ## 5.9.0 - 2025-06-16
 ### Fixed
 - [#255](https://github.com/deviceinsight/kafkactl/pull/255) Set resource name when creating a cluster ACL

--- a/internal/auth/token-provider.go
+++ b/internal/auth/token-provider.go
@@ -27,6 +27,10 @@ func LoadTokenProviderPlugin(pluginName string, options map[string]any, brokers 
 			return nil, err
 		}
 
+		if options == nil {
+			options = make(map[string]any)
+		}
+
 		if err := loadedPlugin.Init(options, brokers); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.
List any dependencies that are required for this change.

Fixes #270

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [ ] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.adoc` was updated
- [ ] a usage example was added to `README.adoc`
- [ ] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
