### PR TITLE
Use already defined formats if possible

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -9,13 +10,10 @@ import (
 )
 
 var dateFormats = []string{
-	"2006-01-02T15:04:05.00000Z",
-	"2006-01-02T15:04:05.000Z",
-	"2006-01-02T15:04:05.000",
-	"2006-01-02T15:04:05Z",
+	time.RFC3339,
 	"2006-01-02T15:04:05",
 	"2006-01-02T15:04",
-	"2006-01-02",
+	time.DateOnly,
 }
 
 func ParseTimestamp(timestamp string) (time.Time, error) {
@@ -41,21 +39,11 @@ func ConvertControlChars(value string) string {
 }
 
 func ContainsString(list []string, element string) bool {
-	for _, it := range list {
-		if it == element {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(list, element)
 }
 
 func ContainsInt32(list []int32, element int32) bool {
-	for _, it := range list {
-		if it == element {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(list, element)
 }
 
 func StringArraysEqual(a, b []string) bool {


### PR DESCRIPTION
# Description

The `time.RFC3339` works better with the `Z` than previously defined formats. Also formats without explicit ms handles ms just fine. 

I also made some small cleanups in the file that I've changed, but I can roll it back if it's too much. 

Fixes  #280 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [ ] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.adoc` was updated
- [ ] a usage example was added to `README.adoc`
- [ ] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
