### PR TITLE
chore: skip generating config files when brokers for default context …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- [#282](https://github.com/deviceinsight/kafkactl/issues/282) Do not generate a config file when brokers for default context are set by environment variable
+
 ## 5.11.1 - 2025-07-28
 
 ## 5.11.0 - 2025-07-16

--- a/internal/global/config.go
+++ b/internal/global/config.go
@@ -332,6 +332,11 @@ func generateDefaultConfig(name string, viperInstance *viper.Viper) error {
 		viperInstance.SetDefault("current-context", getInitialCurrentContext(cfgFile))
 	}
 
+	if os.Getenv(defaultContextPrefix+Brokers) != "" {
+		output.Debugf("skip generating default config file %s, because environment variable %s is set", cfgFile, defaultContextPrefix+Brokers)
+		return nil
+	}
+
 	if err := viperInstance.WriteConfigAs(cfgFile); err != nil {
 		return err
 	}


### PR DESCRIPTION
…is set

# Description

Skip generating config files when brokers for default context is set

This allows user to fully configure it by environment variables.

Fixes #282 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.adoc` was updated
- [ ] a usage example was added to `README.adoc`
- [ ] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
