### PR TITLE
Only warn when config file or context file cannot be created (#282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Alter Broker Command**: New `kafkactl alter broker` command for dynamic broker configuration management without requiring broker restarts
+- Only warn when config file or context file cannot be created (#282)
 
 ## 5.11.1 - 2025-07-28
 

--- a/README.adoc
+++ b/README.adoc
@@ -252,6 +252,18 @@ During initialization _kafkactl_ starts from the current working directory and r
 config file. The recursive lookup ends at the boundary of a git repository (i.e. if a `.git` folder is found).
 This way, _kafkactl_ can be used conveniently anywhere in the git repository.
 
+[#_current_context]
+==== Current context
+
+The current context can be set via commandline argument `--context`, environment variable `CURRENT_CONTEXT` or
+it can be defined in a file.
+
+If no current context is defined, the first context in the config file is used as current context. Additionally,
+in this case a file storing the current context is created.
+
+The file is typically stored next to the config file and named `current-context.yml`.
+The location of the file can be overridden via environment variable `KAFKA_CTL_WRITABLE_CONFIG`.
+
 === Auto completion
 
 ==== bash

--- a/cmd/config/view.go
+++ b/cmd/config/view.go
@@ -1,11 +1,10 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
-	"os"
 
 	"github.com/deviceinsight/kafkactl/v5/internal/output"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -14,21 +13,17 @@ func newViewCmd() *cobra.Command {
 
 	var cmdView = &cobra.Command{
 		Use:   "view",
-		Short: "show contents of config file",
-		Long:  `Shows the contents of the config file that is currently used`,
+		Short: "show current config",
+		Long:  `Shows the merged config that is currently used`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 
-			configFileUsed := viper.ConfigFileUsed()
-			if _, err := os.Stat(configFileUsed); os.IsNotExist(err) {
-				return fmt.Errorf("no config file loaded")
+			c := new(bytes.Buffer)
+
+			if err := viper.WriteConfigTo(c); err != nil {
+				return fmt.Errorf("unable to write config: %v", err)
 			}
 
-			yamlFile, err := os.ReadFile(configFileUsed)
-			if err != nil {
-				return errors.Wrap(err, "unable to read config")
-			}
-
-			output.Infof("%s", yamlFile)
+			output.Infof("%s", c.String())
 			return nil
 		},
 	}

--- a/cmd/config/view.go
+++ b/cmd/config/view.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/deviceinsight/kafkactl/v5/internal/output"
@@ -17,7 +18,12 @@ func newViewCmd() *cobra.Command {
 		Long:  `Shows the contents of the config file that is currently used`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 
-			yamlFile, err := os.ReadFile(viper.ConfigFileUsed())
+			configFileUsed := viper.ConfigFileUsed()
+			if _, err := os.Stat(configFileUsed); os.IsNotExist(err) {
+				return fmt.Errorf("no config file loaded")
+			}
+
+			yamlFile, err := os.ReadFile(configFileUsed)
 			if err != nil {
 				return errors.Wrap(err, "unable to read config")
 			}

--- a/cmd/config/view_test.go
+++ b/cmd/config/view_test.go
@@ -1,9 +1,12 @@
 package config_test
 
 import (
+	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/deviceinsight/kafkactl/v5/internal/output"
 	"github.com/deviceinsight/kafkactl/v5/internal/testutil"
@@ -69,4 +72,102 @@ current-context: default`
 	testutil.AssertEquals(t, defaultConfigContent, string(configContent))
 	testutil.AssertEquals(t, defaultContextContent, string(contextContent))
 	testutil.AssertEquals(t, defaultConfigContent, kafkaCtl.GetStdOut())
+}
+
+func TestViewConfigWorksIfConfigDirIsReadOnly(t *testing.T) {
+
+	tests := []struct {
+		name             string
+		configFileExists bool
+		wantError        string
+	}{
+		{
+			name:      "config_and_context_file_cannot_be_created",
+			wantError: "no config file loaded",
+		},
+		{
+			name:             "config_file_exists_but_context_file_cannot_be_created",
+			configFileExists: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			testutil.StartUnitTest(t)
+
+			tempDir := getTempDir()
+			if err := os.MkdirAll(tempDir, 0755); err != nil {
+				t.Fatalf("unable to create temp dir: %v", err)
+			}
+			defer func(path string) {
+				err := os.RemoveAll(path)
+				if err != nil {
+					output.TestLogf("unable to delete temp dir %s: %v", path, err)
+				}
+			}(tempDir)
+
+			configFile := path.Join(tempDir, "config.yml")
+			contextFile := path.Join(tempDir, "context.yml")
+
+			configContent := `
+contexts:
+    default:
+        brokers: env-broker:9092`
+
+			if tt.configFileExists {
+				if err := os.WriteFile(configFile, []byte(configContent), 0644); err != nil {
+					t.Fatalf("unable to create config file: %v", err)
+				}
+			}
+
+			if err := os.Chmod(tempDir, 0555); err != nil {
+				t.Fatalf("unable to make config file readonly: %v", err)
+			}
+
+			if err := os.Setenv("KAFKA_CTL_CONFIG", configFile); err != nil {
+				t.Fatalf("unable to set env variable: %v", err)
+			}
+
+			if err := os.Setenv("KAFKA_CTL_WRITABLE_CONFIG", contextFile); err != nil {
+				t.Fatalf("unable to set env variable: %v", err)
+			}
+
+			if err := os.Setenv("BROKERS", "env-broker:9092"); err != nil {
+				t.Fatalf("unable to set env variable: %v", err)
+			}
+
+			kafkaCtl := testutil.CreateKafkaCtlCommand()
+
+			_, err := kafkaCtl.Execute("config", "view")
+
+			if tt.wantError == "" && err != nil {
+				t.Fatalf("failed to execute command: %v", err)
+			} else if tt.wantError != "" && err == nil {
+				t.Fatalf("expecting error but got none: %s", tt.wantError)
+				return
+			} else if tt.wantError != "" {
+				testutil.AssertContainSubstring(t, tt.wantError, err.Error())
+				return
+			}
+
+			actualConfigContent, err := os.ReadFile(configFile)
+			if err != nil {
+				t.Fatalf("error reading generated config %s %v", configFile, err)
+			}
+
+			if _, err := os.Stat(contextFile); err == nil {
+				t.Fatalf("context file should not exist %s: %v", contextFile, err)
+			}
+
+			testutil.AssertEquals(t, configContent, string(actualConfigContent))
+			testutil.AssertEquals(t, configContent, kafkaCtl.GetStdOut())
+			testutil.AssertContainSubstring(t, "cannot write config file", kafkaCtl.GetStdErr())
+		})
+	}
+}
+
+func getTempDir() string {
+	timestamp := time.Now().UnixNano()
+	dirName := fmt.Sprintf("test-dir-%d", timestamp)
+	return filepath.Join(os.TempDir(), dirName)
 }

--- a/internal/global/config.go
+++ b/internal/global/config.go
@@ -312,6 +312,9 @@ func generateDefaultConfig(name string, viperInstance *viper.Viper) error {
 	} else if name == writableConfigFileName && os.Getenv(WritableConfigEnvVariable) != "" {
 		// use config file provided via env
 		cfgFile = os.Getenv(WritableConfigEnvVariable)
+	} else if name == writableConfigFileName && os.Getenv(ConfigEnvVariable) != "" {
+		// use config file provided via env as base path
+		cfgFile = filepath.Join(path.Dir(os.Getenv(ConfigEnvVariable)), filename)
 	} else if runtime.GOOS == "windows" {
 		// use different configFile when running on windows
 		for _, configPath := range configPaths {

--- a/internal/global/config.go
+++ b/internal/global/config.go
@@ -322,18 +322,20 @@ func generateDefaultConfig(name string, viperInstance *viper.Viper) error {
 		}
 	}
 
-	if err := os.MkdirAll(filepath.Dir(cfgFile), os.FileMode(0700)); err != nil {
-		return err
-	}
-
 	if name == configFileName {
 		viperInstance.SetDefault("contexts.default.brokers", []string{"localhost:9092"})
 	} else {
 		viperInstance.SetDefault("current-context", getInitialCurrentContext(cfgFile))
 	}
 
+	if err := os.MkdirAll(filepath.Dir(cfgFile), os.FileMode(0700)); err != nil {
+		output.Warnf("cannot creating config file directory: %v", err)
+		return nil
+	}
+
 	if err := viperInstance.WriteConfigAs(cfgFile); err != nil {
-		return err
+		output.Warnf("cannot write config file=%s: %v", cfgFile, err)
+		return nil
 	}
 
 	output.Debugf("generated default config at %s", cfgFile)


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed.
List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.adoc` was updated
- [x] a usage example was added to `README.adoc`
- [x] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
