### PR TITLE
features/protoset-fullname: make sure we match the FullName first before using shortname

### DIFF
--- a/internal/consume/ProtobufMessageDeserializer.go
+++ b/internal/consume/ProtobufMessageDeserializer.go
@@ -21,10 +21,10 @@ type ProtobufMessageDeserializer struct {
 	valueDescriptor protoreflect.MessageDescriptor
 }
 
-func CreateProtobufMessageDeserializer(config internal.ProtobufConfig, keyType, valueType protoreflect.Name) (*ProtobufMessageDeserializer, error) {
+func CreateProtobufMessageDeserializer(config internal.ProtobufConfig, keyType, valueType protoreflect.FullName) (*ProtobufMessageDeserializer, error) {
 	return &ProtobufMessageDeserializer{
-		keyType:         keyType,
-		valueType:       valueType,
+		keyType:         keyType.Name(),
+		valueType:       valueType.Name(),
 		marshalOptions:  config.MarshalOptions,
 		keyDescriptor:   protobuf.ResolveMessageType(config, keyType),
 		valueDescriptor: protobuf.ResolveMessageType(config, valueType),

--- a/internal/consume/consume-operation.go
+++ b/internal/consume/consume-operation.go
@@ -114,7 +114,7 @@ func (operation *Operation) Consume(topic string, flags Flags) error {
 		deserializers = append(deserializers, &avroDeserializer, &protobufDeserializer)
 	}
 
-	deserializer, err := CreateProtobufMessageDeserializer(protobufConfig, protoreflect.Name(flags.KeyProtoType), protoreflect.Name(flags.ValueProtoType))
+	deserializer, err := CreateProtobufMessageDeserializer(protobufConfig, protoreflect.FullName(flags.KeyProtoType), protoreflect.FullName(flags.ValueProtoType))
 	if err != nil {
 		return err
 	}

--- a/internal/helpers/protobuf/protobuf_test.go
+++ b/internal/helpers/protobuf/protobuf_test.go
@@ -40,6 +40,55 @@ message Outer2 {       // Level 0
   }
 }
 `
+const schema2 = `syntax = "proto3";
+package foo.bar.v2;
+
+message Outer {
+	string foo = 1;
+}
+message Outer2 {
+	int32 foo = 1;
+}
+message BarV2 {
+    string value = 1;
+}
+`
+
+func TestResolveMessageType(t *testing.T) {
+	testCases := []struct {
+		msgName          protoreflect.FullName
+		expectedFullName string
+	}{
+		{"foo.bar.Outer", "foo.bar.Outer"},
+		{"foo.bar.Outer2", "foo.bar.Outer2"},
+		{"Outer", "foo.bar.Outer"},
+		{"Outer2", "foo.bar.Outer2"},
+		{"foo.bar.v2.Outer", "foo.bar.v2.Outer"},
+		{"foo.bar.v2.Outer2", "foo.bar.v2.Outer2"},
+	}
+	fileDesc1, err := ParseFileDescriptor(".", map[string]string{".": schema})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fileDesc2, err := ParseFileDescriptor(".", map[string]string{".": schema2})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	descriptorSet := []protoreflect.FileDescriptor{
+		fileDesc1,
+		fileDesc2,
+	}
+
+	for _, tc := range testCases {
+		t.Run(string(tc.msgName), func(t *testing.T) {
+			result := resolveMessageType(descriptorSet, tc.msgName)
+			if tc.expectedFullName != string(result.FullName()) {
+				t.Fatalf("expected: %+v, found: %+v", tc.expectedFullName, result)
+			}
+		})
+	}
+}
 
 func TestComputeIndexes(t *testing.T) {
 	testCases := []struct {

--- a/internal/producer/ProtobufMessageSerializer.go
+++ b/internal/producer/ProtobufMessageSerializer.go
@@ -16,7 +16,7 @@ type ProtobufMessageSerializer struct {
 	valueDescriptor protoreflect.MessageDescriptor
 }
 
-func CreateProtobufMessageSerializer(topic string, context internal.ProtobufConfig, keyType, valueType protoreflect.Name) (*ProtobufMessageSerializer, error) {
+func CreateProtobufMessageSerializer(topic string, context internal.ProtobufConfig, keyType, valueType protoreflect.FullName) (*ProtobufMessageSerializer, error) {
 	valueDescriptor := protobuf.ResolveMessageType(context, valueType)
 	if valueDescriptor == nil && valueType != "" {
 		return nil, errors.Errorf("value message type %q not found in provided files", valueType)

--- a/internal/producer/producer-operation.go
+++ b/internal/producer/producer-operation.go
@@ -96,7 +96,7 @@ func (operation *Operation) Produce(topic string, flags Flags) error {
 
 	if len(context.ProtoFiles) != 0 || len(context.ProtoImportPaths) != 0 || len(context.ProtosetFiles) != 0 {
 
-		serializer, err := CreateProtobufMessageSerializer(topic, context, protoreflect.Name(flags.KeyProtoType), protoreflect.Name(flags.ValueProtoType))
+		serializer, err := CreateProtobufMessageSerializer(topic, context, protoreflect.FullName(flags.KeyProtoType), protoreflect.FullName(flags.ValueProtoType))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Make sure we match the FullName first before using short Name

# Description

When matching with `--value-proto-type`, we want to match the FullName of the protobuf type when possible.

Changes matching to:
1. Match on exact FullName
2. Match on any (short) Name() like before

This fixes cases where two message definitions are present in the same descriptor set, and you need to select between:
- `foo.bar.v1.Outer`
- `foo.bar.v2.Outer`

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Documentation

- [ ] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [X] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
