### PR TITLE
feat: Support configuring SASL version

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -103,6 +103,8 @@ contexts:
       password: admin
       # optional configure sasl mechanism as plaintext, scram-sha256, scram-sha512, oauth (defaults to plaintext)
       mechanism: oauth
+      # optional configure sasl version as v0, v1 (defaults to not configured), Refer to: https://github.com/IBM/sarama/issues/3000#issuecomment-2415829478
+      version: v0
       # optional tokenProvider configuration (only used for 'sasl.mechanism=oauth')
       tokenprovider:
         # plugin to use as token provider implementation (see plugin section)

--- a/internal/common-operation.go
+++ b/internal/common-operation.go
@@ -36,6 +36,7 @@ type SaslConfig struct {
 	Password      string
 	Mechanism     string
 	TokenProvider TokenProvider
+	Version       string
 }
 
 type SchemaRegistryConfig struct {
@@ -205,6 +206,7 @@ func CreateClientContext() (ClientContext, error) {
 	context.Sasl.Username = viper.GetString("contexts." + context.Name + ".sasl.username")
 	context.Sasl.Password = viper.GetString("contexts." + context.Name + ".sasl.password")
 	context.Sasl.Mechanism = viper.GetString("contexts." + context.Name + ".sasl.mechanism")
+	context.Sasl.Version = viper.GetString("contexts." + context.Name + ".sasl.version")
 	context.Sasl.TokenProvider.PluginName = viper.GetString("contexts." + context.Name + ".sasl.tokenProvider.plugin")
 	context.Sasl.TokenProvider.Options = viper.GetStringMap("contexts." + context.Name + ".sasl.tokenProvider.options")
 
@@ -291,6 +293,12 @@ func CreateClientConfig(context *ClientContext) (*sarama.Config, error) {
 		config.Net.SASL.Enable = true
 		config.Net.SASL.User = context.Sasl.Username
 		config.Net.SASL.Password = context.Sasl.Password
+		if strings.EqualFold(context.Sasl.Version, "v0") {
+			config.Net.SASL.Version = sarama.SASLHandshakeV0
+		}
+		if strings.EqualFold(context.Sasl.Version, "v1") {
+			config.Net.SASL.Version = sarama.SASLHandshakeV1
+		}
 		switch context.Sasl.Mechanism {
 		case "scram-sha512":
 			config.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA512


### PR DESCRIPTION
# Description

According to this link https://github.com/IBM/sarama/issues/3000#issuecomment-2415829478 when connecting to brokers older than 1.0, the SASL version needs to be specified.

## Type of change

- [x] New feature Support configuring SASL version


## Documentation
- [x] the configuration yaml was changed and the example config in `README.adoc` was updated

