### PR TITLE
Bugfix: Fetch all messages in a time range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fixed a bug where consuming a time range near the end of a topic would not work correctly
 
 ### Fixed
 - [#313](https://github.com/deviceinsight/kafkactl/issues/313) Use `IncrementalAlterConfigs` API to fix TOCTOU race condition when altering topic/broker configs concurrently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Fixed a bug where consuming a time range near the end of a topic would not work correctly
 
 ### Fixed
 - [#313](https://github.com/deviceinsight/kafkactl/issues/313) Use `IncrementalAlterConfigs` API to fix TOCTOU race condition when altering topic/broker configs concurrently
 - [#299](https://github.com/deviceinsight/kafkactl/issues/299) Consumer authorization errors now return non-zero exit code
 - [#256](https://github.com/deviceinsight/kafkactl/issues/256) `alter topic --replication-factor` infinite loop when broker is unavailable
+- [#317](https://github.com/deviceinsight/kafkactl/issues/317) Fixed a bug where consuming a time range near the end of a topic would not work correctly
 
 ## 5.18.0 - 2026-02-12
 

--- a/cmd/consume/consume_test.go
+++ b/cmd/consume/consume_test.go
@@ -153,6 +153,59 @@ func TestConsumeFromTimestampIntegration(t *testing.T) {
 	testutil.AssertArraysEquals(t, []string{"g", "h"}, messages)
 }
 
+func TestConsumeSingleMessageInTimeRangeIntegration(t *testing.T) {
+	testutil.StartIntegrationTest(t)
+
+	topicName := testutil.CreateTopic(t, "consume-single-msg", "--partitions", "3")
+
+	// Produce some messages before the target time range
+	testutil.ProduceMessageOnPartition(t, topicName, "key-1", "before1", 0, 0)
+	testutil.ProduceMessageOnPartition(t, topicName, "key-2", "before2", 1, 0)
+
+	time.Sleep(2 * time.Millisecond)
+	t1 := time.Now().UnixMilli()
+	time.Sleep(2 * time.Millisecond)
+
+	// Produce exactly ONE message on each partition within the time range
+	testutil.ProduceMessageOnPartition(t, topicName, "key-3", "single0", 0, 1)
+	testutil.ProduceMessageOnPartition(t, topicName, "key-4", "single1", 1, 1)
+	testutil.ProduceMessageOnPartition(t, topicName, "key-5", "single2", 2, 0)
+
+	time.Sleep(2 * time.Millisecond)
+	t2 := time.Now().UnixMilli()
+	time.Sleep(2 * time.Millisecond)
+
+	// Produce messages after the target time range
+	testutil.ProduceMessageOnPartition(t, topicName, "key-6", "after1", 0, 2)
+	testutil.ProduceMessageOnPartition(t, topicName, "key-7", "after2", 1, 2)
+
+	// Test: consume with time range that contains exactly one message per partition
+	kafkaCtl := testutil.CreateKafkaCtlCommand()
+	if _, err := kafkaCtl.Execute("consume", topicName, "--from-timestamp", strconv.FormatInt(t1, 10), "--to-timestamp", strconv.FormatInt(t2, 10), "--exit"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	output := kafkaCtl.GetStdOut()
+	messages := strings.Split(strings.TrimSpace(output), "\n")
+
+	// Should get exactly 3 messages (one from each partition)
+	if len(messages) != 3 {
+		t.Fatalf("expected 3 messages, got %d: %v", len(messages), messages)
+	}
+
+	// Verify we got the correct messages (order may vary due to partition consumption)
+	testutil.AssertContains(t, "single0", messages)
+	testutil.AssertContains(t, "single1", messages)
+	testutil.AssertContains(t, "single2", messages)
+
+	// Verify we did NOT get the before/after messages
+	for _, msg := range messages {
+		if strings.Contains(msg, "before") || strings.Contains(msg, "after") {
+			t.Fatalf("got unexpected message: %s", msg)
+		}
+	}
+}
+
 func TestConsumeRegistryProtobufWithNestedDependenciesIntegration(t *testing.T) {
 	testutil.StartIntegrationTest(t)
 

--- a/cmd/consume/consume_test.go
+++ b/cmd/consume/consume_test.go
@@ -122,15 +122,10 @@ func TestConsumeFromTimestampIntegration(t *testing.T) {
 	kafkaCtl := testutil.CreateKafkaCtlCommand()
 	t1Formatted := time.UnixMilli(t1).Format("2006-01-02T15:04:05.000Z")
 	t2Formatted := time.UnixMilli(t2).Format("2006-01-02T15:04:05.000Z")
-	t.Logf("DEBUG: t1=%d (%s), t2=%d (%s)", t1, t1Formatted, t2, t2Formatted)
 	if _, err := kafkaCtl.Execute("consume", topicName, "--from-timestamp", t1Formatted, "--to-timestamp", t2Formatted); err != nil {
 		t.Fatalf("failed to execute command: %v", err)
 	}
-	stdout := kafkaCtl.GetStdOut()
-	stderr := kafkaCtl.GetStdErr()
-	t.Logf("DEBUG: stdout=%q", stdout)
-	t.Logf("DEBUG: stderr contains: %s", stderr)
-	messages := strings.Split(strings.TrimSpace(stdout), "\n")
+	messages := strings.Split(strings.TrimSpace(kafkaCtl.GetStdOut()), "\n")
 	testutil.AssertArraysEquals(t, []string{"c", "d", "e", "f"}, messages)
 
 	// test --from-timestamp with --to-timestamp with unix epoch millis timestamps

--- a/cmd/consume/consume_test.go
+++ b/cmd/consume/consume_test.go
@@ -122,10 +122,15 @@ func TestConsumeFromTimestampIntegration(t *testing.T) {
 	kafkaCtl := testutil.CreateKafkaCtlCommand()
 	t1Formatted := time.UnixMilli(t1).Format("2006-01-02T15:04:05.000Z")
 	t2Formatted := time.UnixMilli(t2).Format("2006-01-02T15:04:05.000Z")
+	t.Logf("DEBUG: t1=%d (%s), t2=%d (%s)", t1, t1Formatted, t2, t2Formatted)
 	if _, err := kafkaCtl.Execute("consume", topicName, "--from-timestamp", t1Formatted, "--to-timestamp", t2Formatted); err != nil {
 		t.Fatalf("failed to execute command: %v", err)
 	}
-	messages := strings.Split(strings.TrimSpace(kafkaCtl.GetStdOut()), "\n")
+	stdout := kafkaCtl.GetStdOut()
+	stderr := kafkaCtl.GetStdErr()
+	t.Logf("DEBUG: stdout=%q", stdout)
+	t.Logf("DEBUG: stderr contains: %s", stderr)
+	messages := strings.Split(strings.TrimSpace(stdout), "\n")
 	testutil.AssertArraysEquals(t, []string{"c", "d", "e", "f"}, messages)
 
 	// test --from-timestamp with --to-timestamp with unix epoch millis timestamps

--- a/internal/consume/PartitionConsumer.go
+++ b/internal/consume/PartitionConsumer.go
@@ -151,8 +151,21 @@ func getOffsetBounds(client *sarama.Client, topic string, flags Flags, currentPa
 	}
 	if endOffset, err = getEndOffset(client, topic, flags, currentPartition); err != nil {
 		return ErrOffset, ErrOffset, err
-	} else if startOffset == endOffset {
-		endOffset = sarama.OffsetNewest //nothing to consume on this partition
+	}
+	output.Debugf("raw offsets: start=%d end=%d (before adjustment) on partition %d", startOffset, endOffset, currentPartition)
+
+	// When to-timestamp is specified and GetOffset returns -1, it means the timestamp
+	// is beyond all messages. We need to get the actual newest offset to consume up to it.
+	if endOffset == sarama.OffsetNewest && flags.ToTimestamp != "" {
+		if endOffset, err = (*client).GetOffset(topic, currentPartition, sarama.OffsetNewest); err != nil {
+			return ErrOffset, ErrOffset, err
+		}
+		output.Debugf("to-timestamp beyond messages, using newest offset %d on partition %d", endOffset, currentPartition)
+	}
+
+	// Check if there are any messages in the range before adjusting endOffset
+	if endOffset != sarama.OffsetNewest && startOffset >= endOffset {
+		endOffset = sarama.OffsetNewest // nothing to consume on this partition
 	} else if endOffset != sarama.OffsetNewest {
 		endOffset = endOffset - 1
 	}

--- a/internal/consume/PartitionConsumer.go
+++ b/internal/consume/PartitionConsumer.go
@@ -156,21 +156,22 @@ func getOffsetBounds(client *sarama.Client, topic string, flags Flags, currentPa
 	}
 	output.Debugf("raw offsets: start=%d end=%d (before adjustment) on partition %d", startOffset, endOffset, currentPartition)
 
-	// When to-timestamp is specified and GetOffset returns -1, it means the timestamp
-	// is beyond all messages. We need to get the actual newest offset to consume up to it.
-	if endOffset == sarama.OffsetNewest && flags.ToTimestamp != "" {
+	// If BOTH startOffset and endOffset are -1 when using timestamps, it means both timestamps
+	// are beyond all messages, so there's nothing to consume
+	if startOffset == sarama.OffsetNewest && endOffset == sarama.OffsetNewest && flags.ToTimestamp != "" {
+		output.Debugf("both from and to timestamps beyond messages, marking partition %d as empty", currentPartition)
+		// Leave both as -1 to skip partition
+	} else if endOffset == sarama.OffsetNewest && flags.ToTimestamp != "" {
+		// When to-timestamp is specified and GetOffset returns -1, it means the timestamp
+		// is beyond all messages. We need to get the actual newest offset to consume up to it.
 		if endOffset, err = (*client).GetOffset(topic, currentPartition, sarama.OffsetNewest); err != nil {
 			return ErrOffset, ErrOffset, err
 		}
 		output.Debugf("to-timestamp beyond messages, using newest offset %d on partition %d", endOffset, currentPartition)
 	}
 
-	// If startOffset is -1 (from-timestamp beyond messages) and we have a to-timestamp,
-	// it means there are no messages in the time range, so mark as empty
-	if startOffset == sarama.OffsetNewest && flags.ToTimestamp != "" {
-		endOffset = sarama.OffsetNewest // nothing to consume on this partition
-		output.Debugf("from-timestamp beyond messages, marking partition %d as empty", currentPartition)
-	} else if endOffset != sarama.OffsetNewest && startOffset > endOffset {
+	// Check if there are no messages in the range
+	if endOffset != sarama.OffsetNewest && startOffset > endOffset {
 		// Check if there are any messages in the range BEFORE adjusting endOffset
 		// Note: startOffset == endOffset means there's ONE message at that offset
 		endOffset = sarama.OffsetNewest // nothing to consume on this partition

--- a/internal/consume/PartitionConsumer.go
+++ b/internal/consume/PartitionConsumer.go
@@ -75,11 +75,13 @@ func (c *PartitionConsumer) Start(ctx context.Context, flags Flags, messages cha
 
 			if lastOffset == -1 && (flags.Exit || flags.Tail > 0 || flags.ToTimestamp != "") {
 				output.Debugf("Skipping empty partition %d", partitionID)
+				pc.AsyncClose()
 				return nil
 			} else if lastOffset == -1 || initialOffset <= lastOffset {
 				output.Debugf("Start consuming partition %d from offset %d to %d", partitionID, initialOffset, lastOffset)
 			} else {
-				output.Debugf("Skipping partition %d", partitionID)
+				output.Debugf("Skipping partition %d (initialOffset=%d > lastOffset=%d)", partitionID, initialOffset, lastOffset)
+				pc.AsyncClose()
 				return nil
 			}
 
@@ -163,11 +165,19 @@ func getOffsetBounds(client *sarama.Client, topic string, flags Flags, currentPa
 		output.Debugf("to-timestamp beyond messages, using newest offset %d on partition %d", endOffset, currentPartition)
 	}
 
-	// Check if there are any messages in the range before adjusting endOffset
-	if endOffset != sarama.OffsetNewest && startOffset >= endOffset {
+	// If startOffset is -1 (from-timestamp beyond messages) and we have a to-timestamp,
+	// it means there are no messages in the time range, so mark as empty
+	if startOffset == sarama.OffsetNewest && flags.ToTimestamp != "" {
 		endOffset = sarama.OffsetNewest // nothing to consume on this partition
+		output.Debugf("from-timestamp beyond messages, marking partition %d as empty", currentPartition)
+	} else if endOffset != sarama.OffsetNewest && startOffset > endOffset {
+		// Check if there are any messages in the range BEFORE adjusting endOffset
+		// Note: startOffset == endOffset means there's ONE message at that offset
+		endOffset = sarama.OffsetNewest // nothing to consume on this partition
+		output.Debugf("no messages in range (start=%d > end=%d), marking partition %d as empty", startOffset, endOffset, currentPartition)
 	} else if endOffset != sarama.OffsetNewest {
 		endOffset = endOffset - 1
+		output.Debugf("adjusted endOffset to %d on partition %d", endOffset, currentPartition)
 	}
 	if flags.Tail > 0 && startOffset == sarama.OffsetNewest {
 		// When --tail is used compute startOffset so that it minimizes the number of messages consumed

--- a/internal/consume/PartitionConsumer.go
+++ b/internal/consume/PartitionConsumer.go
@@ -170,12 +170,9 @@ func getOffsetBounds(client *sarama.Client, topic string, flags Flags, currentPa
 		output.Debugf("to-timestamp beyond messages, using newest offset %d on partition %d", endOffset, currentPartition)
 	}
 
-	// Check if there are no messages in the range
 	if endOffset != sarama.OffsetNewest && startOffset > endOffset {
-		// Check if there are any messages in the range BEFORE adjusting endOffset
-		// Note: startOffset == endOffset means there's ONE message at that offset
-		endOffset = sarama.OffsetNewest // nothing to consume on this partition
 		output.Debugf("no messages in range (start=%d > end=%d), marking partition %d as empty", startOffset, endOffset, currentPartition)
+		endOffset = sarama.OffsetNewest // nothing to consume on this partition
 	} else if endOffset != sarama.OffsetNewest {
 		endOffset = endOffset - 1
 		output.Debugf("adjusted endOffset to %d on partition %d", endOffset, currentPartition)


### PR DESCRIPTION
# Description

Hi

I have topic that ticks like a clock (10 partitions, null keys). Every minute at second 14 there is a new message. I consumed that with kafkactl and noticed that if I consume very recent time range I would get mixed results. For example, at XX:08 if I consumed messages from XX:00 to XX:05 I could usually get from 0-2 messages, depending on how they ended up in different partitions.

I digged deeper and found out, when consuming a time range (`--from-timestamp 2026-03-13T13:00 --to-timestamp 2026-03-13T13:05`) when there was only one message in a given partition the message was not printed.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix

## Documentation

- [X] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [X] tests for the changes have been implemented

In my environment there were 2 integration test failures (cmd/consume TestConsumeFromTimestampIntegration and cmd/reset TestResetCGOToDatetimeIntegration), but they were also present in main, so I assumed that this changed did not cause them. Lets see what github actions say. 

I'm quite familiar with Kafka, but this is actually my first time writing Go 😅, so I used a bit a of AI help. 