### PR TITLE
fix: alter topic --replication-factor infinite loop when broker is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [#313](https://github.com/deviceinsight/kafkactl/issues/313) Use `IncrementalAlterConfigs` API to fix TOCTOU race condition when altering topic/broker configs concurrently
 - [#299](https://github.com/deviceinsight/kafkactl/issues/299) Consumer authorization errors now return non-zero exit code
+- [#256](https://github.com/deviceinsight/kafkactl/issues/256) `alter topic --replication-factor` infinite loop when broker is unavailable
 
 ## 5.18.0 - 2026-02-12
 

--- a/internal/topic/topic-operation.go
+++ b/internal/topic/topic-operation.go
@@ -371,20 +371,43 @@ func (operation *Operation) AlterTopic(topic string, flags AlterTopicFlags) erro
 
 	if flags.ReplicationFactor > 0 {
 
-		var brokers = client.Brokers()
+		var allBrokers = client.Brokers()
 
-		if int(flags.ReplicationFactor) > len(brokers) {
-			return errors.Errorf("Replication factor for topic '%s' must not exceed the number of available brokers", topic)
+		var availableBrokers []*sarama.Broker
+		for _, broker := range allBrokers {
+			connected, err := broker.Connected()
+			if err != nil {
+				output.Debugf("error checking broker %d connectivity: %v", broker.ID(), err)
+				continue
+			}
+			if connected {
+				availableBrokers = append(availableBrokers, broker)
+			} else {
+				output.Warnf("broker %d (%s) is not available and will be excluded from replica assignment", broker.ID(), broker.Addr())
+			}
 		}
 
+		if len(availableBrokers) == 0 {
+			return errors.Errorf("no available brokers found for topic '%s'", topic)
+		}
+
+		if int(flags.ReplicationFactor) > len(availableBrokers) {
+			return errors.Errorf("Replication factor for topic '%s' must not exceed the number of available brokers (%d available)", topic, len(availableBrokers))
+		}
+
+		// Only include available brokers in the replica count map.
+		// Replicas on unavailable brokers will be preferentially removed by getTargetReplicas
+		// because they won't have an entry in this map.
 		brokerReplicaCount := make(map[int32]int)
-		for _, broker := range brokers {
+		for _, broker := range availableBrokers {
 			brokerReplicaCount[broker.ID()] = 0
 		}
 
 		for _, partition := range t.Partitions {
 			for _, brokerID := range partition.Replicas {
-				brokerReplicaCount[brokerID]++
+				if _, ok := brokerReplicaCount[brokerID]; ok {
+					brokerReplicaCount[brokerID]++
+				}
 			}
 		}
 
@@ -419,6 +442,8 @@ func (operation *Operation) AlterTopic(topic string, flags AlterTopicFlags) erro
 				partitions[0] = p.ID
 			}
 
+			const maxReassignmentWait = 10 * time.Minute
+			deadline := time.Now().Add(maxReassignmentWait)
 			assignmentRunning := true
 
 			for assignmentRunning {
@@ -433,8 +458,13 @@ func (operation *Operation) AlterTopic(topic string, flags AlterTopicFlags) erro
 					for partitionID, statusPartition := range statusTopic {
 						output.Infof("reassignment running for topic=%s partition=%d: replicas:%v addingReplicas:%v removingReplicas:%v",
 							topic, partitionID, statusPartition.Replicas, statusPartition.AddingReplicas, statusPartition.RemovingReplicas)
-						time.Sleep(5 * time.Second)
 						assignmentRunning = true
+					}
+					if assignmentRunning {
+						if time.Now().After(deadline) {
+							return errors.Errorf("partition reassignment for topic '%s' did not complete within %s", topic, maxReassignmentWait)
+						}
+						time.Sleep(5 * time.Second)
 					}
 				} else {
 					output.Debugf("Emtpy list partition reassignment result returned (len status: %d)", len(status))
@@ -607,6 +637,14 @@ func getTargetReplicas(currentReplicas []int32, brokerReplicaCount map[int32]int
 		sort.Slice(replicas, func(i, j int) bool {
 			brokerI := replicas[i]
 			brokerJ := replicas[j]
+			_, availableI := brokerReplicaCount[brokerI]
+			_, availableJ := brokerReplicaCount[brokerJ]
+
+			// Unavailable brokers (not in brokerReplicaCount) should be sorted to the end
+			// so they are removed first when decreasing replication factor
+			if availableI != availableJ {
+				return availableI
+			}
 			return brokerReplicaCount[brokerI] < brokerReplicaCount[brokerJ] || (brokerReplicaCount[brokerI] == brokerReplicaCount[brokerJ] && brokerI < brokerJ)
 		})
 

--- a/internal/topic/topic-operation.go
+++ b/internal/topic/topic-operation.go
@@ -650,8 +650,19 @@ func getTargetReplicas(currentReplicas []int32, brokerReplicaCount map[int32]int
 
 		lastReplica := replicas[len(replicas)-1]
 		replicas = replicas[:len(replicas)-1]
-		brokerReplicaCount[lastReplica]--
+		if _, ok := brokerReplicaCount[lastReplica]; ok {
+			brokerReplicaCount[lastReplica]--
+		}
 	}
+
+	// Strip unavailable replicas so the increase phase replaces them with available brokers.
+	var availableReplicas []int32
+	for _, r := range replicas {
+		if _, ok := brokerReplicaCount[r]; ok {
+			availableReplicas = append(availableReplicas, r)
+		}
+	}
+	replicas = availableReplicas
 
 	var unusedBrokerIDs []int32
 

--- a/internal/topic/topic-operation_test.go
+++ b/internal/topic/topic-operation_test.go
@@ -1,0 +1,147 @@
+package topic
+
+import (
+	"testing"
+)
+
+func TestGetTargetReplicasDecrease(t *testing.T) {
+
+	// 3 brokers, current replicas on brokers 1,2,3, target RF=1
+	// Should keep broker with lowest replica count
+	brokerReplicaCount := map[int32]int{
+		1: 2,
+		2: 3,
+		3: 1,
+	}
+
+	replicas, err := getTargetReplicas([]int32{1, 2, 3}, brokerReplicaCount, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(replicas) != 1 {
+		t.Fatalf("expected 1 replica, got %d", len(replicas))
+	}
+	// Should keep broker 3 (lowest replica count)
+	if replicas[0] != 3 {
+		t.Fatalf("expected broker 3, got %d", replicas[0])
+	}
+}
+
+func TestGetTargetReplicasIncrease(t *testing.T) {
+
+	// 3 brokers, current replicas on broker 1 only, target RF=3
+	brokerReplicaCount := map[int32]int{
+		1: 2,
+		2: 0,
+		3: 1,
+	}
+
+	replicas, err := getTargetReplicas([]int32{1}, brokerReplicaCount, 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(replicas) != 3 {
+		t.Fatalf("expected 3 replicas, got %d", len(replicas))
+	}
+	// broker 1 was already there, brokers 2 and 3 should be added
+	// broker 2 has the lowest count so should be added first
+	if replicas[0] != 1 {
+		t.Fatalf("expected broker 1 first, got %d", replicas[0])
+	}
+	if replicas[1] != 2 {
+		t.Fatalf("expected broker 2 second, got %d", replicas[1])
+	}
+	if replicas[2] != 3 {
+		t.Fatalf("expected broker 3 third, got %d", replicas[2])
+	}
+}
+
+func TestGetTargetReplicasDecreaseWithUnavailableBroker(t *testing.T) {
+
+	// Scenario from issue #256: broker 3 is unavailable
+	// brokerReplicaCount only contains available brokers (1 and 2)
+	// Current replicas include broker 3 (which is unavailable)
+	brokerReplicaCount := map[int32]int{
+		1: 2,
+		2: 2,
+	}
+
+	// Partition has replicas on brokers 3 and 1
+	// Since broker 3 is not in brokerReplicaCount (unavailable),
+	// it should be removed first when decreasing
+	replicas, err := getTargetReplicas([]int32{3, 1}, brokerReplicaCount, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(replicas) != 1 {
+		t.Fatalf("expected 1 replica, got %d", len(replicas))
+	}
+	// Should keep broker 1 (available) and remove broker 3 (unavailable)
+	if replicas[0] != 1 {
+		t.Fatalf("expected broker 1, got %d", replicas[0])
+	}
+}
+
+func TestGetTargetReplicasDecreaseMultipleUnavailableBrokers(t *testing.T) {
+
+	// Multiple unavailable brokers should all be removed first
+	brokerReplicaCount := map[int32]int{
+		1: 3,
+		2: 3,
+	}
+
+	// Replicas on brokers 3, 4, 1, 2 - brokers 3 and 4 are unavailable
+	// Target RF=2, should remove unavailable brokers first
+	replicas, err := getTargetReplicas([]int32{3, 4, 1, 2}, brokerReplicaCount, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(replicas) != 2 {
+		t.Fatalf("expected 2 replicas, got %d", len(replicas))
+	}
+	// Should keep brokers 1 and 2 (available) and remove 3 and 4 (unavailable)
+	for _, r := range replicas {
+		if r == 3 || r == 4 {
+			t.Fatalf("unavailable broker %d should have been removed", r)
+		}
+	}
+}
+
+func TestGetTargetReplicasDecreaseAllUnavailable(t *testing.T) {
+
+	// Edge case: all current replicas are on unavailable brokers
+	brokerReplicaCount := map[int32]int{
+		1: 0,
+		2: 0,
+	}
+
+	// Current replicas are on brokers 3 and 4 (both unavailable)
+	replicas, err := getTargetReplicas([]int32{3, 4}, brokerReplicaCount, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should still work, keeping one of them
+	if len(replicas) != 1 {
+		t.Fatalf("expected 1 replica, got %d", len(replicas))
+	}
+}
+
+func TestGetTargetReplicasNotEnoughBrokers(t *testing.T) {
+
+	brokerReplicaCount := map[int32]int{
+		1: 1,
+	}
+
+	_, err := getTargetReplicas([]int32{1}, brokerReplicaCount, 3)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+	if err.Error() != "not enough brokers" {
+		t.Fatalf("expected 'not enough brokers' error, got: %v", err)
+	}
+}

--- a/internal/topic/topic-operation_test.go
+++ b/internal/topic/topic-operation_test.go
@@ -131,6 +131,28 @@ func TestGetTargetReplicasDecreaseAllUnavailable(t *testing.T) {
 	}
 }
 
+func TestGetTargetReplicasDecreaseUnavailableThenIncrease(t *testing.T) {
+
+	// All current replicas on unavailable brokers; result must use only available brokers.
+	brokerReplicaCount := map[int32]int{
+		1: 0,
+		2: 0,
+	}
+
+	replicas, err := getTargetReplicas([]int32{3, 4, 5}, brokerReplicaCount, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(replicas) != 2 {
+		t.Fatalf("expected 2 replicas, got %d", len(replicas))
+	}
+	for _, r := range replicas {
+		if r == 3 || r == 4 || r == 5 {
+			t.Fatalf("unavailable broker %d should not be in result %v", r, replicas)
+		}
+	}
+}
+
 func TestGetTargetReplicasNotEnoughBrokers(t *testing.T) {
 
 	brokerReplicaCount := map[int32]int{


### PR DESCRIPTION
## Summary

- Fixes `alter topic --replication-factor` entering an infinite loop when a broker is unavailable (e.g., down or unreachable)
- Filters brokers by connectivity (`broker.Connected()`) before building replica assignments, so replicas are only assigned to available brokers
- Prioritizes removing replicas from unavailable brokers when decreasing replication factor
- Adds a 10-minute timeout to the reassignment polling loop as a safety net

## Changes

### `internal/topic/topic-operation.go`
- **`AlterTopic`**: Uses `broker.Connected()` to filter available brokers. Only available brokers are included in `brokerReplicaCount`. Unavailable brokers are warned about via `output.Warnf`. The replication factor validation now checks against available broker count. The reassignment polling loop now has a 10-minute deadline.
- **`getTargetReplicas`**: When decreasing replication factor, brokers not present in `brokerReplicaCount` (i.e., unavailable) are sorted to the end of the replica list so they are removed first.

### `internal/topic/topic-operation_test.go` (new)
- Unit tests for `getTargetReplicas` covering: normal increase/decrease, decrease with unavailable brokers, multiple unavailable brokers, all unavailable, and not enough brokers error.

### `CHANGELOG.md`
- Added entry under `[Unreleased]`

Closes #256