### PR TITLE
feat: support SASL secrets in k8s proxy mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- [#322](https://github.com/deviceinsight/kafkactl/issues/322) Support SASL credential injection in pods via k8s secret
+
 ### Fixed
 - [#313](https://github.com/deviceinsight/kafkactl/issues/313) Use `IncrementalAlterConfigs` API to fix TOCTOU race condition when altering topic/broker configs concurrently
 - [#299](https://github.com/deviceinsight/kafkactl/issues/299) Consumer authorization errors now return non-zero exit code

--- a/README.adoc
+++ b/README.adoc
@@ -127,6 +127,13 @@ contexts:
       imagePullSecret: registry-secret
       # optional: secret containing tls certificates (e.g. ca.crt, cert.crt, key.key)
       tlsSecret: tls-secret
+      # optional: inject SASL credentials into the pod via a Kubernetes secret instead of plaintext env vars.
+      # name and create are mutually exclusive.
+      saslSecret:
+        # reference an existing secret with keys "username" and "password" (kafkactl will not manage its lifecycle)
+        name: sasl-secret
+        # alternatively, let kafkactl create a short-lived secret from the local sasl config and delete it after the pod exits
+        create: false
       # optional: Username to impersonate for the kubectl command
       asUser: user
       # optional: serviceAccount to use for the pod
@@ -396,6 +403,54 @@ contexts:
       # set insecure to true to ignore all tls verification (defaults to false)
       insecure: false
 ----
+
+If your Kafka cluster requires SASL authentication, you can avoid passing credentials as plaintext environment
+variables in the pod spec by using `saslSecret`. There are two options:
+
+. Reference an existing secret (must contain keys `username` and `password`):
++
+[,$yaml]
+----
+contexts:
+  kafka-cluster:
+    brokers:
+      - broker1:9092
+      - broker2:9092
+    kubernetes:
+      enabled: true
+      kubeContext: k8s-cluster
+      namespace: k8s-namespace
+      saslSecret:
+        name: my-sasl-secret
+    sasl:
+      enabled: true
+      mechanism: scram-sha256
+----
+
+. Let kafkactl create a short-lived secret based on credentials from the local config:
++
+[,$yaml]
+----
+contexts:
+  kafka-cluster:
+    brokers:
+      - broker1:9092
+      - broker2:9092
+    kubernetes:
+      enabled: true
+      kubeContext: k8s-cluster
+      namespace: k8s-namespace
+      saslSecret:
+        create: true
+    sasl:
+      enabled: true
+      mechanism: scram-sha256
+      username: my-user
+      password: my-password
+----
++
+kafkactl will create the secret before the pod starts, verify no secret with the generated name already exists,
+and delete it once the pod exits.
 
 Instead of directly talking to kafka brokers a kafkactl docker image is deployed as a pod into the kubernetes
 cluster, and the defined namespace. Standard-Input and Standard-Output are then wired between the pod and your shell

--- a/internal/common-operation.go
+++ b/internal/common-operation.go
@@ -81,6 +81,11 @@ type K8sToleration struct {
 	Effect   string `json:"effect" yaml:"effect"`
 }
 
+type K8sSaslSecretConfig struct {
+	Name   string
+	Create bool
+}
+
 type K8sConfig struct {
 	Enabled         bool
 	Binary          string
@@ -90,6 +95,7 @@ type K8sConfig struct {
 	Image           string
 	ImagePullSecret string
 	TLSSecret       string
+	SaslSecret      K8sSaslSecretConfig
 	ServiceAccount  string
 	AsUser          string
 	KeepPod         bool
@@ -228,6 +234,8 @@ func CreateClientContext() (ClientContext, error) {
 	context.Kubernetes.Image = viper.GetString("contexts." + context.Name + ".kubernetes.image")
 	context.Kubernetes.ImagePullSecret = viper.GetString("contexts." + context.Name + ".kubernetes.imagePullSecret")
 	context.Kubernetes.TLSSecret = viper.GetString("contexts." + context.Name + ".kubernetes.tlsSecret")
+	context.Kubernetes.SaslSecret.Name = viper.GetString("contexts." + context.Name + ".kubernetes.saslSecret.name")
+	context.Kubernetes.SaslSecret.Create = viper.GetBool("contexts." + context.Name + ".kubernetes.saslSecret.create")
 	context.Kubernetes.ServiceAccount = viper.GetString("contexts." + context.Name + ".kubernetes.serviceAccount")
 	context.Kubernetes.AsUser = viper.GetString("contexts." + context.Name + ".kubernetes.asUser")
 	context.Kubernetes.KeepPod = viper.GetBool("contexts." + context.Name + ".kubernetes.keepPod")

--- a/internal/k8s/executer_test.go
+++ b/internal/k8s/executer_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/deviceinsight/kafkactl/v5/internal"
+	"github.com/deviceinsight/kafkactl/v5/internal/global"
 	"github.com/deviceinsight/kafkactl/v5/internal/k8s"
 )
 
@@ -392,4 +393,94 @@ func indexOf(element string, data []string) int {
 		}
 	}
 	return -1
+}
+
+func TestExecWithSaslSecretNameProvided(t *testing.T) {
+	var clientContext internal.ClientContext
+	clientContext.Kubernetes.SaslSecret.Name = "my-sasl-secret"
+
+	testRunner := TestRunner{}
+	testRunner.response = []byte(sampleKubectlVersionOutput)
+	var runner k8s.Runner = &testRunner
+
+	exec, err := k8s.NewExecutor(context.Background(), clientContext, runner)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = exec.Run("scratch", "/kafkactl", []string{"version"}, []string{"ENV_A=1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	overrideType := extractParam(t, testRunner.args, "--override-type")
+	if overrideType != "json" {
+		t.Fatalf("wrong override-type: %s", overrideType)
+	}
+
+	overrides := extractParam(t, testRunner.args, "--overrides")
+	var podOverrides k8s.JSONPatchType
+	if err := json.Unmarshal([]byte(overrides), &podOverrides); err != nil {
+		t.Fatalf("unable to unmarshal overrides: %v", err)
+	}
+
+	var envVar struct {
+		Name      string `json:"name"`
+		ValueFrom struct {
+			SecretKeyRef struct {
+				Name string `json:"name"`
+				Key  string `json:"key"`
+			} `json:"secretKeyRef"`
+		} `json:"valueFrom"`
+	}
+
+	foundUsername := false
+	foundPassword := false
+	for _, patch := range podOverrides {
+		if patch.Path != "/spec/containers/0/env/-" || patch.Op != "add" {
+			continue
+		}
+		valueBytes, _ := json.Marshal(patch.Value)
+		if err := json.Unmarshal(valueBytes, &envVar); err != nil {
+			t.Fatalf("unable to parse env var patch value: %v", err)
+		}
+		if envVar.ValueFrom.SecretKeyRef.Name != "my-sasl-secret" {
+			t.Fatalf("wrong secret name in patch: %s", envVar.ValueFrom.SecretKeyRef.Name)
+		}
+		if envVar.Name == global.SaslUsername && envVar.ValueFrom.SecretKeyRef.Key == "username" {
+			foundUsername = true
+		}
+		if envVar.Name == global.SaslPassword && envVar.ValueFrom.SecretKeyRef.Key == "password" {
+			foundPassword = true
+		}
+	}
+	if !foundUsername {
+		t.Fatalf("username secretKeyRef patch not found in overrides: %s", overrides)
+	}
+	if !foundPassword {
+		t.Fatalf("password secretKeyRef patch not found in overrides: %s", overrides)
+	}
+}
+
+func TestExecWithSaslSecretNameAndCreateBothSetReturnsError(t *testing.T) {
+	var clientContext internal.ClientContext
+	clientContext.Kubernetes.SaslSecret.Name = "my-sasl-secret"
+	clientContext.Kubernetes.SaslSecret.Create = true
+
+	testRunner := TestRunner{}
+	testRunner.response = []byte(sampleKubectlVersionOutput)
+	var runner k8s.Runner = &testRunner
+
+	exec, err := k8s.NewExecutor(context.Background(), clientContext, runner)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = exec.Run("scratch", "/kafkactl", []string{"version"}, []string{})
+	if err == nil {
+		t.Fatal("expected error when both saslSecret.name and saslSecret.create are set")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
 }

--- a/internal/k8s/executor.go
+++ b/internal/k8s/executor.go
@@ -24,26 +24,30 @@ type Version struct {
 }
 
 type executor struct {
-	kubectlBinary   string
-	image           string
-	imagePullSecret string
-	tlsSecret       string
-	version         Version
-	runner          Runner
-	clientID        string
-	kubeConfig      string
-	kubeContext     string
-	serviceAccount  string
-	asUser          string
-	keepPod         bool
-	namespace       string
-	labels          map[string]string
-	annotations     map[string]string
-	nodeSelector    map[string]string
-	affinity        map[string]any
-	resources       map[string]any
-	tolerations     []internal.K8sToleration
-	ctx             context.Context
+	kubectlBinary    string
+	image            string
+	imagePullSecret  string
+	tlsSecret        string
+	saslSecretName   string
+	createSaslSecret bool
+	saslSecret       string
+	saslConfig       internal.SaslConfig
+	version          Version
+	runner           Runner
+	clientID         string
+	kubeConfig       string
+	kubeContext      string
+	serviceAccount   string
+	asUser           string
+	keepPod          bool
+	namespace        string
+	labels           map[string]string
+	annotations      map[string]string
+	nodeSelector     map[string]string
+	affinity         map[string]any
+	resources        map[string]any
+	tolerations      []internal.K8sToleration
+	ctx              context.Context
 }
 
 const letterBytes = "abcdefghijklmnpqrstuvwxyz123456789"
@@ -106,26 +110,29 @@ func newExecutor(ctx context.Context, clientContext internal.ClientContext, runn
 	}
 
 	return &executor{
-		kubectlBinary:   clientContext.Kubernetes.Binary,
-		version:         version,
-		image:           clientContext.Kubernetes.Image,
-		imagePullSecret: clientContext.Kubernetes.ImagePullSecret,
-		tlsSecret:       clientContext.Kubernetes.TLSSecret,
-		clientID:        internal.GetClientID(&clientContext, ""),
-		kubeConfig:      clientContext.Kubernetes.KubeConfig,
-		kubeContext:     clientContext.Kubernetes.KubeContext,
-		namespace:       clientContext.Kubernetes.Namespace,
-		serviceAccount:  clientContext.Kubernetes.ServiceAccount,
-		asUser:          clientContext.Kubernetes.AsUser,
-		keepPod:         clientContext.Kubernetes.KeepPod,
-		labels:          clientContext.Kubernetes.Labels,
-		annotations:     clientContext.Kubernetes.Annotations,
-		nodeSelector:    clientContext.Kubernetes.NodeSelector,
-		affinity:        clientContext.Kubernetes.Affinity,
-		resources:       clientContext.Kubernetes.Resources,
-		tolerations:     clientContext.Kubernetes.Tolerations,
-		runner:          runner,
-		ctx:             ctx,
+		kubectlBinary:    clientContext.Kubernetes.Binary,
+		version:          version,
+		image:            clientContext.Kubernetes.Image,
+		imagePullSecret:  clientContext.Kubernetes.ImagePullSecret,
+		tlsSecret:        clientContext.Kubernetes.TLSSecret,
+		saslSecretName:   clientContext.Kubernetes.SaslSecret.Name,
+		createSaslSecret: clientContext.Kubernetes.SaslSecret.Create,
+		saslConfig:       clientContext.Sasl,
+		clientID:         internal.GetClientID(&clientContext, ""),
+		kubeConfig:       clientContext.Kubernetes.KubeConfig,
+		kubeContext:      clientContext.Kubernetes.KubeContext,
+		namespace:        clientContext.Kubernetes.Namespace,
+		serviceAccount:   clientContext.Kubernetes.ServiceAccount,
+		asUser:           clientContext.Kubernetes.AsUser,
+		keepPod:          clientContext.Kubernetes.KeepPod,
+		labels:           clientContext.Kubernetes.Labels,
+		annotations:      clientContext.Kubernetes.Annotations,
+		nodeSelector:     clientContext.Kubernetes.NodeSelector,
+		affinity:         clientContext.Kubernetes.Affinity,
+		resources:        clientContext.Kubernetes.Resources,
+		tolerations:      clientContext.Kubernetes.Tolerations,
+		runner:           runner,
+		ctx:              ctx,
 	}, nil
 }
 
@@ -136,7 +143,52 @@ func (kubectl *executor) SetKubectlBinary(bin string) {
 func (kubectl *executor) Run(dockerImageType, entryPoint string, kafkactlArgs []string, podEnvironment []string, additionalKubectlArgs ...string) error {
 	dockerImage := getDockerImage(kubectl.image, dockerImageType)
 
-	podName := fmt.Sprintf("kafkactl-%s-%s", strings.ToLower(kubectl.clientID), randomString(4))
+	suffix := randomString(4)
+	podName := fmt.Sprintf("kafkactl-%s-%s", strings.ToLower(kubectl.clientID), suffix)
+
+	if kubectl.saslSecretName != "" && kubectl.createSaslSecret {
+		return errors.Errorf("kubernetes.saslSecret.name and kubernetes.saslSecret.create are mutually exclusive")
+	}
+
+	if kubectl.createSaslSecret {
+		// RBAC check
+		canIArgs := []string{"auth", "can-i", "create", "secrets"}
+		canIArgs = kubectl.addGlobalArgs(canIArgs)
+		if bytes, err := kubectl.runner.ExecuteAndReturn(kubectl.kubectlBinary, canIArgs); err != nil {
+			return errors.Wrapf(err, "RBAC check failed in namespace %s", kubectl.namespace)
+		} else if !strings.Contains(string(bytes), "yes") {
+			return errors.Errorf("no permission to create secrets in namespace %s", kubectl.namespace)
+		}
+
+		kubectl.saslSecret = fmt.Sprintf("kafkactl-sasl-%s", suffix)
+
+		// ensure we don't take over lifecycle of an existing secret
+		checkArgs := kubectl.addGlobalArgs([]string{"get", "secret", kubectl.saslSecret})
+		if _, err := kubectl.runner.ExecuteAndReturn(kubectl.kubectlBinary, checkArgs); err == nil {
+			return errors.Errorf("secret %s already exists; kafkactl will not manage the lifecycle of existing secrets", kubectl.saslSecret)
+		}
+
+		createSecretArgs := []string{
+			"create", "secret", "generic", kubectl.saslSecret,
+			fmt.Sprintf("--from-literal=username=%s", kubectl.saslConfig.Username),
+			fmt.Sprintf("--from-literal=password=%s", kubectl.saslConfig.Password),
+		}
+		createSecretArgs = kubectl.addGlobalArgs(createSecretArgs)
+
+		if _, err := kubectl.runner.ExecuteAndReturn(kubectl.kubectlBinary, createSecretArgs); err != nil {
+			return errors.Wrapf(err, "unable to create secret %s", kubectl.saslSecret)
+		}
+
+		defer func() {
+			deleteSecretArgs := []string{"delete", "secret", kubectl.saslSecret, "--ignore-not-found=true"}
+			deleteSecretArgs = kubectl.addGlobalArgs(deleteSecretArgs)
+			if _, err := kubectl.runner.ExecuteAndReturn(kubectl.kubectlBinary, deleteSecretArgs); err != nil {
+				output.Warnf("unable to delete secret %s: %v", kubectl.saslSecret, err)
+			}
+		}()
+	} else if kubectl.saslSecretName != "" {
+		kubectl.saslSecret = kubectl.saslSecretName
+	}
 
 	kubectlArgs := []string{
 		"run", "-i", "--restart=Never", podName,
@@ -149,13 +201,7 @@ func (kubectl *executor) Run(dockerImageType, entryPoint string, kafkactlArgs []
 		kubectlArgs = slices.Insert(kubectlArgs, 1, "--rm")
 	}
 
-	if kubectl.kubeConfig != "" {
-		kubectlArgs = append(kubectlArgs, "--kubeconfig", kubectl.kubeConfig)
-	}
-
-	if kubectl.asUser != "" {
-		kubectlArgs = append(kubectlArgs, "--as", kubectl.asUser)
-	}
+	kubectlArgs = kubectl.addGlobalArgs(kubectlArgs)
 
 	podOverrides := kubectl.createPodOverrides()
 	if len(podOverrides) > 0 {
@@ -167,9 +213,6 @@ func (kubectl *executor) Run(dockerImageType, entryPoint string, kafkactlArgs []
 		kubectlArgs = append(kubectlArgs, "--override-type", "json")
 		kubectlArgs = append(kubectlArgs, "--overrides", string(podOverridesJSON))
 	}
-
-	kubectlArgs = append(kubectlArgs, "--context", kubectl.kubeContext)
-	kubectlArgs = append(kubectlArgs, "--namespace", kubectl.namespace)
 
 	for _, env := range podEnvironment {
 		kubectlArgs = append(kubectlArgs, "--env", env)
@@ -243,6 +286,21 @@ func filter(slice []string, predicate func(string) bool) (ret []string) {
 		}
 	}
 	return
+}
+
+func (kubectl *executor) addGlobalArgs(args []string) []string {
+	if kubectl.kubeConfig != "" {
+		args = append(args, "--kubeconfig", kubectl.kubeConfig)
+	}
+
+	if kubectl.asUser != "" {
+		args = append(args, "--as", kubectl.asUser)
+	}
+
+	args = append(args, "--context", kubectl.kubeContext)
+	args = append(args, "--namespace", kubectl.namespace)
+
+	return args
 }
 
 func (kubectl *executor) exec(args []string) error {

--- a/internal/k8s/executor.go
+++ b/internal/k8s/executor.go
@@ -163,8 +163,10 @@ func (kubectl *executor) Run(dockerImageType, entryPoint string, kafkactlArgs []
 		kubectl.saslSecret = fmt.Sprintf("kafkactl-sasl-%s", suffix)
 
 		// ensure we don't take over lifecycle of an existing secret
-		checkArgs := kubectl.addGlobalArgs([]string{"get", "secret", kubectl.saslSecret})
-		if _, err := kubectl.runner.ExecuteAndReturn(kubectl.kubectlBinary, checkArgs); err == nil {
+		checkArgs := kubectl.addGlobalArgs([]string{"get", "secret", kubectl.saslSecret, "--ignore-not-found"})
+		if bytes, err := kubectl.runner.ExecuteAndReturn(kubectl.kubectlBinary, checkArgs); err != nil {
+			return errors.Wrapf(err, "unable to check if secret %s exists", kubectl.saslSecret)
+		} else if len(strings.TrimSpace(string(bytes))) > 0 {
 			return errors.Errorf("secret %s already exists; kafkactl will not manage the lifecycle of existing secrets", kubectl.saslSecret)
 		}
 
@@ -178,12 +180,15 @@ func (kubectl *executor) Run(dockerImageType, entryPoint string, kafkactlArgs []
 		if _, err := kubectl.runner.ExecuteAndReturn(kubectl.kubectlBinary, createSecretArgs); err != nil {
 			return errors.Wrapf(err, "unable to create secret %s", kubectl.saslSecret)
 		}
+		output.Debugf("created sasl secret: %s", kubectl.saslSecret)
 
 		defer func() {
 			deleteSecretArgs := []string{"delete", "secret", kubectl.saslSecret, "--ignore-not-found=true"}
 			deleteSecretArgs = kubectl.addGlobalArgs(deleteSecretArgs)
 			if _, err := kubectl.runner.ExecuteAndReturn(kubectl.kubectlBinary, deleteSecretArgs); err != nil {
 				output.Warnf("unable to delete secret %s: %v", kubectl.saslSecret, err)
+			} else {
+				output.Debugf("deleted sasl secret: %s", kubectl.saslSecret)
 			}
 		}()
 	} else if kubectl.saslSecretName != "" {

--- a/internal/k8s/k8s-operation.go
+++ b/internal/k8s/k8s-operation.go
@@ -180,8 +180,12 @@ func parsePodEnvironment(context internal.ClientContext) []string {
 	envVariables = appendStringIfDefined(envVariables, global.TLSCertKey, context.TLS.CertKey)
 	envVariables = appendBool(envVariables, global.TLSInsecure, context.TLS.Insecure)
 	envVariables = appendBool(envVariables, global.SaslEnabled, context.Sasl.Enabled)
-	envVariables = appendStringIfDefined(envVariables, global.SaslUsername, context.Sasl.Username)
-	envVariables = appendStringIfDefined(envVariables, global.SaslPassword, context.Sasl.Password)
+
+	if context.Kubernetes.SaslSecret.Name == "" && !context.Kubernetes.SaslSecret.Create {
+		envVariables = appendStringIfDefined(envVariables, global.SaslUsername, context.Sasl.Username)
+		envVariables = appendStringIfDefined(envVariables, global.SaslPassword, context.Sasl.Password)
+	}
+
 	envVariables = appendStringIfDefined(envVariables, global.SaslMechanism, context.Sasl.Mechanism)
 	envVariables = appendStringIfDefined(envVariables, global.SaslTokenProviderPlugin, context.Sasl.TokenProvider.PluginName)
 	envVariables = appendMapIfDefined(envVariables, global.SaslTokenProviderOptions, context.Sasl.TokenProvider.Options)

--- a/internal/k8s/k8s-operation_test.go
+++ b/internal/k8s/k8s-operation_test.go
@@ -99,3 +99,41 @@ func TestAllAvailableEnvironmentVariablesAreParsed(t *testing.T) {
 	testutil.AssertEquals(t, "WaitForAll", envMap[global.ProducerRequiredAcks])
 	testutil.AssertEquals(t, "1234", envMap[global.ProducerMaxMessageBytes])
 }
+
+func TestSaslCredentialsNotInPodEnvironmentWhenSaslSecretNameIsSet(t *testing.T) {
+	var context internal.ClientContext
+	context.Sasl.Enabled = true
+	context.Sasl.Username = "user"
+	context.Sasl.Password = "pass"
+	context.Kubernetes.SaslSecret.Name = "my-sasl-secret"
+
+	environment := k8s.ParsePodEnvironment(context)
+
+	for _, envVar := range environment {
+		if strings.HasPrefix(envVar, global.SaslUsername+"=") {
+			t.Fatalf("%s should not be in pod environment when saslSecret.name is set", global.SaslUsername)
+		}
+		if strings.HasPrefix(envVar, global.SaslPassword+"=") {
+			t.Fatalf("%s should not be in pod environment when saslSecret.name is set", global.SaslPassword)
+		}
+	}
+}
+
+func TestSaslCredentialsNotInPodEnvironmentWhenSaslSecretCreateIsEnabled(t *testing.T) {
+	var context internal.ClientContext
+	context.Sasl.Enabled = true
+	context.Sasl.Username = "user"
+	context.Sasl.Password = "pass"
+	context.Kubernetes.SaslSecret.Create = true
+
+	environment := k8s.ParsePodEnvironment(context)
+
+	for _, envVar := range environment {
+		if strings.HasPrefix(envVar, global.SaslUsername+"=") {
+			t.Fatalf("%s should not be in pod environment when saslSecret.create is enabled", global.SaslUsername)
+		}
+		if strings.HasPrefix(envVar, global.SaslPassword+"=") {
+			t.Fatalf("%s should not be in pod environment when saslSecret.create is enabled", global.SaslPassword)
+		}
+	}
+}

--- a/internal/k8s/pod_overrides.go
+++ b/internal/k8s/pod_overrides.go
@@ -1,5 +1,7 @@
 package k8s
 
+import "github.com/deviceinsight/kafkactl/v5/internal/global"
+
 type imagePullSecretType struct {
 	Name string `json:"name"`
 }
@@ -17,6 +19,20 @@ type volumeMountType struct {
 	Name      string `json:"name"`
 	MountPath string `json:"mountPath"`
 	ReadOnly  bool   `json:"readOnly"`
+}
+
+type secretKeyRefType struct {
+	Name string `json:"name"`
+	Key  string `json:"key"`
+}
+
+type valueFromType struct {
+	SecretKeyRef secretKeyRefType `json:"secretKeyRef"`
+}
+
+type secretEnvVarType struct {
+	Name      string        `json:"name"`
+	ValueFrom valueFromType `json:"valueFrom"`
 }
 
 // JSONPatchOperation represents a single JSON Patch operation (RFC 6902)
@@ -57,6 +73,26 @@ func (kubectl *executor) createPodOverrides() JSONPatchType {
 			Path: "/spec/containers/0/volumeMounts",
 			Value: []volumeMountType{
 				{Name: "kafkactl-tls", MountPath: "/etc/ssl/certs/kafkactl", ReadOnly: true},
+			},
+		})
+	}
+
+	// Add SASL secret if specified
+	if kubectl.saslSecret != "" {
+		patches = append(patches, JSONPatchOperation{
+			Op:   "add",
+			Path: "/spec/containers/0/env/-",
+			Value: secretEnvVarType{
+				Name:      global.SaslUsername,
+				ValueFrom: valueFromType{SecretKeyRef: secretKeyRefType{Name: kubectl.saslSecret, Key: "username"}},
+			},
+		})
+		patches = append(patches, JSONPatchOperation{
+			Op:   "add",
+			Path: "/spec/containers/0/env/-",
+			Value: secretEnvVarType{
+				Name:      global.SaslPassword,
+				ValueFrom: valueFromType{SecretKeyRef: secretKeyRefType{Name: kubectl.saslSecret, Key: "password"}},
 			},
 		})
 	}


### PR DESCRIPTION
First of all: thanks for providing this tool, it has proven time and again to be really helpful! :heart: 

--- 

# Description
 
When kafkactl runs a command in Kubernetes proxy mode, SASL credentials are currently injected as plain environment variables into the pod spec. Anyone with basic permissions to describe or get pods can read them in plaintext, which is generally considered a security risk.

Even worse, if you decide as a workaround to omit the credentials in the config file and instead create and exec into a pod via the attach sub-command and manually run

```bash
export SASL_USERNAME=<username>
export SASL_PASSWORD=<password>
```

these commands will be echo'd to stdout. In an environment with a rather open central logging solution, everyone with access would be able to read such exposed logs.

To make credential leakage or sniffing a bit harder, this PR adds a `kubernetes.saslSecret` config block with two options for injecting credentials more securely via `secretKeyRef`:

```yaml
  kubernetes:
    saslSecret:
      name: my-sasl-secret     # option 1: reference an existing secret
      # create: true           # option 2: kafkactl manages entire secret lifecycle
````

With option 2, credentials could even be omitted entirely from the config file and use e.g. external secrets to retrieve them from a centralized secret store automatically.

Before creating, kafkactl verifies it has permission to manage secrets in the configured namespace and that no secret with the generated name already exists (to avoid taking over the lifecycle of externally managed secrets). The secret shares the same random suffix as the pod, making the two easy to correlate.

Secret creation and deletion output is suppressed to avoid polluting the actual command output.

The feature is opt-in, direct env var injection is kept as default behavior.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [x] the configuration yaml was changed and the example config in `README.adoc` was updated
- [x] a usage example was added to `README.adoc`
- [x] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))

Both, the `saslSecret.name` and `saslSecret.create` flows are covered by unit tests. I did not add any integration tests since at least the `saslSecret.create` path requires three sequential kubectl calls that the kubectl mock cannot correctly simulate without significant extension. Also, this would IMHO not add substantially more value given both flows are already well covered by said unit tests.