### PR TITLE
feat(produce): treat "null" string as null value/key by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - [#322](https://github.com/deviceinsight/kafkactl/issues/322) Support SASL credential injection in pods via k8s secret
+### Changed
+- [#308](https://github.com/deviceinsight/kafkactl/issues/308) `--value null` and `--key null` now produce a null (tombstone) value/key instead of the literal string `"null"`. To write the literal string `"null"`, use base64 encoding: `--value bnVsbA== --value-encoding base64`
 
 ### Fixed
 - [#313](https://github.com/deviceinsight/kafkactl/issues/313) Use `IncrementalAlterConfigs` API to fix TOCTOU race condition when altering topic/broker configs concurrently

--- a/cmd/produce/produce_test.go
+++ b/cmd/produce/produce_test.go
@@ -426,7 +426,7 @@ func TestProduceNullKeyStringTreatedAsNullKeyIntegration(t *testing.T) {
 	}
 
 	record := strings.ReplaceAll(kafkaCtl.GetStdOut(), "\n", " ")
-	testutil.AssertContainSubstring(t, "key: null", record)
+	testutil.AssertContainNoSubstring(t, "key:", record)
 	testutil.AssertContainSubstring(t, "value: test-value", record)
 }
 

--- a/cmd/produce/produce_test.go
+++ b/cmd/produce/produce_test.go
@@ -387,6 +387,70 @@ func TestProduceAvroMessageWithUnionAvroJsonIntegration(t *testing.T) {
 	testutil.AssertContainSubstring(t, `"ExpiresOn":{"string":"2022-12-12"}`, stdout)
 }
 
+func TestProduceNullValueStringTreatedAsTombstoneIntegration(t *testing.T) {
+	testutil.StartIntegrationTest(t)
+
+	topicName := testutil.CreateTopic(t, "produce-topic")
+
+	kafkaCtl := testutil.CreateKafkaCtlCommand()
+
+	if _, err := kafkaCtl.Execute("produce", topicName, "--key", "test-key", "--value", "null"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	testutil.AssertEquals(t, "message produced (partition=0\toffset=0)", kafkaCtl.GetStdOut())
+
+	if _, err := kafkaCtl.Execute("consume", topicName, "--from-beginning", "-o", "yaml", "--exit"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	record := strings.ReplaceAll(kafkaCtl.GetStdOut(), "\n", " ")
+	testutil.AssertContainSubstring(t, "value: null", record)
+}
+
+func TestProduceNullKeyStringTreatedAsNullKeyIntegration(t *testing.T) {
+	testutil.StartIntegrationTest(t)
+
+	topicName := testutil.CreateTopic(t, "produce-topic")
+
+	kafkaCtl := testutil.CreateKafkaCtlCommand()
+
+	if _, err := kafkaCtl.Execute("produce", topicName, "--key", "null", "--value", "test-value"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	testutil.AssertEquals(t, "message produced (partition=0\toffset=0)", kafkaCtl.GetStdOut())
+
+	if _, err := kafkaCtl.Execute("consume", topicName, "--from-beginning", "-o", "yaml", "--exit"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	record := strings.ReplaceAll(kafkaCtl.GetStdOut(), "\n", " ")
+	testutil.AssertContainSubstring(t, "key: null", record)
+	testutil.AssertContainSubstring(t, "value: test-value", record)
+}
+
+func TestProduceNullStringLiteralViaBase64Integration(t *testing.T) {
+	testutil.StartIntegrationTest(t)
+
+	topicName := testutil.CreateTopic(t, "produce-topic")
+
+	kafkaCtl := testutil.CreateKafkaCtlCommand()
+
+	// base64("null") = "bnVsbA==" — use encoding to write the literal string "null"
+	if _, err := kafkaCtl.Execute("produce", topicName, "--key", "test-key", "--value", "bnVsbA==", "--value-encoding", "base64"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	testutil.AssertEquals(t, "message produced (partition=0\toffset=0)", kafkaCtl.GetStdOut())
+
+	if _, err := kafkaCtl.Execute("consume", topicName, "--from-beginning", "--exit", "--print-keys"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	testutil.AssertEquals(t, "test-key#null", kafkaCtl.GetStdOut())
+}
+
 func TestProduceTombstoneIntegration(t *testing.T) {
 	testutil.StartIntegrationTest(t)
 

--- a/internal/producer/producer-operation.go
+++ b/internal/producer/producer-operation.go
@@ -129,14 +129,24 @@ func (operation *Operation) Produce(topic string, flags Flags) error {
 		return errors.New("parameters --null-value and --value cannot be used together")
 	}
 
+	if flags.Value == "null" {
+		flags.NullValue = true
+		flags.Value = ""
+	}
+
+	var msgKey *string
+	if flags.Key != "null" {
+		msgKey = &flags.Key
+	}
+
 	if flags.NullValue || flags.Value != "" {
 		// produce a single message
 		var message *sarama.ProducerMessage
 
 		if flags.NullValue {
-			message, err = serializers.Serialize(input.Message{Key: &flags.Key}, flags)
+			message, err = serializers.Serialize(input.Message{Key: msgKey}, flags)
 		} else {
-			message, err = serializers.Serialize(input.Message{Key: &flags.Key, Value: &flags.Value}, flags)
+			message, err = serializers.Serialize(input.Message{Key: msgKey, Value: &flags.Value}, flags)
 		}
 
 		if err != nil {

--- a/internal/testutil/test_util.go
+++ b/internal/testutil/test_util.go
@@ -233,6 +233,13 @@ func AssertContainSubstring(t *testing.T, expected, actual string) {
 	}
 }
 
+func AssertContainNoSubstring(t *testing.T, expected, actual string) {
+	t.Helper()
+	if strings.Contains(actual, expected) {
+		t.Fatalf("expected string NOT to contain: %s actual: %s", expected, actual)
+	}
+}
+
 func AssertContains(t *testing.T, expected string, array []string) {
 	t.Helper()
 	if !util.ContainsString(array, expected) {


### PR DESCRIPTION
## Summary

- `--value null` and `--key null` now produce a null (tombstone) value/key instead of the literal string `"null"`
- To write the literal string `"null"`, use base64 encoding: `--value bnVsbA== --value-encoding base64`
- No new flags required

## Motivation

Multiple users accidentally wrote the string `"null"` to topics by running commands like `kafkactl produce my-topic -k "x" -v null`, causing poison pills in production. See #308.

## Tests

- `TestProduceNullValueStringTreatedAsTombstoneIntegration`
- `TestProduceNullKeyStringTreatedAsNullKeyIntegration`
- `TestProduceNullStringLiteralViaBase64Integration` (documents the escape hatch)

Closes #308