### PR TITLE
reset consumer group offsets in parallel across partitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `reset offset` now resets partitions concurrently, significantly speeding up offset resets on topics with many partitions
+
 ## 5.19.0 - 2026-05-11
 
 ### Added

--- a/cmd/reset/reset-consumer-group-offset_test.go
+++ b/cmd/reset/reset-consumer-group-offset_test.go
@@ -1,6 +1,8 @@
 package reset_test
 
 import (
+	"encoding/json"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -50,6 +52,74 @@ func TestResetCGOForSingleTopicIntegration(t *testing.T) {
 
 	testutil.VerifyConsumerGroupOffset(t, group1, topicName, 0)
 	testutil.VerifyConsumerGroupOffset(t, group2, topicName, 2)
+}
+
+type resetPartitionOffset struct {
+	Partition     int32
+	CurrentOffset int64 `json:"currentOffset"`
+	TargetOffset  int64 `json:"targetOffset"`
+}
+
+func TestResetCGOForTopicWithManyPartitionsIntegration(t *testing.T) {
+
+	testutil.StartIntegrationTest(t)
+
+	const partitionCount = 20
+
+	topicName := testutil.CreateTopic(t, "reset-cgo-parallel", "--partitions", strconv.Itoa(partitionCount))
+
+	group := testutil.CreateConsumerGroup(t, "reset-cgo-parallel", topicName)
+
+	for partition := int32(0); partition < partitionCount; partition++ {
+		testutil.ProduceMessageOnPartition(t, topicName, "test-key", "test-value1", partition, 0)
+		testutil.ProduceMessageOnPartition(t, topicName, "test-key", "test-value2", partition, 1)
+	}
+
+	kafkaCtl := testutil.CreateKafkaCtlCommand()
+
+	if _, err := kafkaCtl.Execute("reset", "consumer-group-offset", group, "--topic", topicName,
+		"--newest", "--execute", "-o", "json"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	resetResults := parseResetPartitionOffsets(t, kafkaCtl.GetStdOut())
+
+	testutil.AssertIntEquals(t, partitionCount, len(resetResults))
+
+	for i, result := range resetResults {
+		testutil.AssertIntEquals(t, i, int(result.Partition))
+		testutil.AssertIntEquals(t, 0, int(result.CurrentOffset))
+		testutil.AssertIntEquals(t, 2, int(result.TargetOffset))
+	}
+
+	// the reset command only reports what it committed - re-fetch the offsets from the
+	// broker in a fresh command to confirm the concurrent resets were actually persisted
+	kafkaCtl = testutil.CreateKafkaCtlCommand()
+
+	if _, err := kafkaCtl.Execute("reset", "consumer-group-offset", group, "--topic", topicName,
+		"--oldest", "-o", "json"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	verifyResults := parseResetPartitionOffsets(t, kafkaCtl.GetStdOut())
+
+	testutil.AssertIntEquals(t, partitionCount, len(verifyResults))
+
+	for i, result := range verifyResults {
+		testutil.AssertIntEquals(t, i, int(result.Partition))
+		testutil.AssertIntEquals(t, 2, int(result.CurrentOffset))
+		testutil.AssertIntEquals(t, 0, int(result.TargetOffset))
+	}
+}
+
+func parseResetPartitionOffsets(t *testing.T, output string) []resetPartitionOffset {
+	t.Helper()
+
+	var results []resetPartitionOffset
+	if err := json.Unmarshal([]byte(output), &results); err != nil {
+		t.Fatalf("failed to parse reset output: %v\noutput was:\n%s", err, output)
+	}
+	return results
 }
 
 func TestResetCGOForMultipleTopicsIntegration(t *testing.T) {

--- a/internal/consumergroupoffsets/OffsetResettingConsumer.go
+++ b/internal/consumergroupoffsets/OffsetResettingConsumer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/deviceinsight/kafkactl/v5/internal/consume"
 	"github.com/deviceinsight/kafkactl/v5/internal/output"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 )
 
 type partitionOffsets struct {
@@ -62,13 +63,28 @@ func (consumer *OffsetResettingConsumer) Setup(session sarama.ConsumerGroupSessi
 			return errors.Wrap(err, "failed to list partitions")
 		}
 
-		for _, partition := range partitions {
-			offset, err := resetOffset(&consumer.client, consumer.topicName, partition, flags, groupOffsets, session)
-			if err != nil {
-				return err
-			}
-			offsets = append(offsets, offset)
+		results := make([]partitionOffsets, len(partitions))
+		var resetErrorGroup errgroup.Group
+		resetErrorGroup.SetLimit(100)
+
+		for i, partition := range partitions {
+			index := i
+			partition := partition
+			resetErrorGroup.Go(func() error {
+				offset, err := resetOffset(&consumer.client, consumer.topicName, partition, flags, groupOffsets, session)
+				if err != nil {
+					return err
+				}
+				results[index] = offset
+				return nil
+			})
 		}
+
+		if err := resetErrorGroup.Wait(); err != nil {
+			return err
+		}
+
+		offsets = append(offsets, results...)
 	}
 
 	if flags.OutputFormat != "" {


### PR DESCRIPTION
# Description
This pr aims to remedy a situation where we want to reset a consumer-group offsets, but it could take a few minutes for topics with a large amount of partitions. Sometimes, during production incidents, these minutes could be very precious.

In order to achieve the reset goal faster, the code would now perform the offset reset in parallel, concurrently across partitions instead of one partition at a time.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Documentation

- [X] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [ ] the configuration yaml was changed and the example config in `README.adoc` was updated
- [ ] a usage example was added to `README.adoc`
- [ ] tests for the changes have been implemented (see: [Testing your changes](https://github.com/deviceinsight/kafkactl/blob/main/.github/contributing.md#testing-your-changes))
