### PR TITLE
fix: correct timezone handling in datetime-based integration tests

### DIFF
--- a/cmd/consume/consume_test.go
+++ b/cmd/consume/consume_test.go
@@ -120,8 +120,8 @@ func TestConsumeFromTimestampIntegration(t *testing.T) {
 
 	// test --from-timestamp with --to-timestamp with formatted dates
 	kafkaCtl := testutil.CreateKafkaCtlCommand()
-	t1Formatted := time.UnixMilli(t1).Format("2006-01-02T15:04:05.000Z")
-	t2Formatted := time.UnixMilli(t2).Format("2006-01-02T15:04:05.000Z")
+	t1Formatted := time.UnixMilli(t1).UTC().Format("2006-01-02T15:04:05.000Z")
+	t2Formatted := time.UnixMilli(t2).UTC().Format("2006-01-02T15:04:05.000Z")
 	if _, err := kafkaCtl.Execute("consume", topicName, "--from-timestamp", t1Formatted, "--to-timestamp", t2Formatted); err != nil {
 		t.Fatalf("failed to execute command: %v", err)
 	}

--- a/cmd/reset/reset-consumer-group-offset_test.go
+++ b/cmd/reset/reset-consumer-group-offset_test.go
@@ -145,7 +145,7 @@ func TestResetCGOToDatetimeIntegration(t *testing.T) {
 	time.Sleep(1 * time.Millisecond) // need to have messaged produced at different milliseconds to have reproducible test
 
 	t1 := time.Now()
-	t1Formatted := t1.Format("2006-01-02T15:04:05.000Z")
+	t1Formatted := t1.UTC().Format("2006-01-02T15:04:05.000Z")
 
 	testutil.ProduceMessage(t, topicName, "test-key", "c", 0, 2)
 	testutil.ProduceMessage(t, topicName, "test-key", "d", 0, 3)


### PR DESCRIPTION
## Description

`TestConsumeFromTimestampIntegration` and `TestResetCGOToDatetimeIntegration` fail when run on any machine whose local timezone isn't UTC (e.g. `make integration_test` on a dev laptop set to Europe/Berlin), while passing fine in CI (which runs in UTC).

Root cause: both tests build a filter timestamp via `time.Time.Format("2006-01-02T15:04:05.000Z")`. The trailing `Z` in that layout is not a timezone-conversion directive (only `Z07:00`/`Z0700` are) — it's just a literal character. Formatting a **Local** `time.Time` with it therefore produces the local wall-clock string with a misleading `Z` suffix that looks like UTC but isn't.

On the parsing side, `internal/util.ParseTimestamp` tries `time.RFC3339` first via `time.ParseInLocation(time.RFC3339, s, Local)`. Since the input string's `Z` matches RFC3339's `Z07:00` zone verb, Go treats it as an explicit UTC marker and **ignores** the `Local` location argument (this is documented `ParseInLocation` behavior: an explicit zone in the input always wins over the passed-in location). The result: the parsed cutoff is off by exactly the host's UTC offset, shifting the query window away from the actual message timestamps and making both tests get empty results.

Fix: call `.UTC()` before formatting, so the literal `Z` is accurate.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing

- Verified locally (Europe/Berlin, UTC+2 in July) that both tests fail before this change and pass after, without needing to force `TZ=UTC`.
- Ran full `go test -short ./...` and the full `cmd/consume`/`cmd/reset` integration suites against a local docker-compose Kafka cluster — all pass.
- `golangci-lint run` clean.

Test-only change, no user-facing behavior affected, so no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)