### PR TITLE
Add resource-name filtering to ACL deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- [#298](https://github.com/deviceinsight/kafkactl/issues/298) Support filtering ACL deletion by resource name
+
 ## 5.20.0 - 2026-07-30
 
 ### Changed

--- a/README.adoc
+++ b/README.adoc
@@ -1406,6 +1406,8 @@ kafkactl delete acl --cluster --operation any --pattern any
 kafkactl delete acl --groups --operation describe --pattern prefixed --allow
 # delete all topic acls for a principal
 kafkactl delete acl --topics --operation any --pattern any --prinicipal User:myUser
+# delete all topic acls for a resource name
+kafkactl delete acl --topics --operation any --pattern any --resource-name my-topic
 # delete all topic acls for a host
 kafkactl delete acl --topics --operation any --pattern any --host my-host
 ----

--- a/cmd/deletion/delete-acl-command_test.go
+++ b/cmd/deletion/delete-acl-command_test.go
@@ -1,0 +1,20 @@
+package deletion
+
+import "testing"
+
+func TestDeleteACLResourceNameFlag(t *testing.T) {
+	cmd := newDeleteACLCmd()
+	flag := cmd.Flags().Lookup("resource-name")
+
+	if flag == nil {
+		t.Fatal("resource-name flag is not registered")
+	}
+
+	if flag.Shorthand != "r" {
+		t.Fatalf("resource-name shorthand = %q, want %q", flag.Shorthand, "r")
+	}
+
+	if flag.DefValue != "" {
+		t.Fatalf("resource-name default = %q, want empty", flag.DefValue)
+	}
+}

--- a/cmd/deletion/delete-acl-resource-name_test.go
+++ b/cmd/deletion/delete-acl-resource-name_test.go
@@ -1,0 +1,48 @@
+package deletion_test
+
+import (
+	"testing"
+
+	"github.com/deviceinsight/kafkactl/v5/internal/acl"
+	"github.com/deviceinsight/kafkactl/v5/internal/testutil"
+)
+
+func TestDeleteAclByResourceNameIntegration(t *testing.T) {
+	testutil.StartIntegrationTestWithContext(t, "sasl-admin")
+
+	kafkaCtl := testutil.CreateKafkaCtlCommand()
+	selectedTopic := testutil.CreateTopic(t, "acl-topic-selected")
+	remainingTopic := testutil.CreateTopic(t, "acl-topic-remaining")
+
+	for _, topicName := range []string{selectedTopic, remainingTopic} {
+		if _, err := kafkaCtl.Execute("create", "acl", "--topic", topicName, "--operation", "read", "--allow", "--principal", "User:user"); err != nil {
+			t.Fatalf("failed to execute command: %v", err)
+		}
+	}
+
+	if _, err := kafkaCtl.Execute("delete", "acl", "--topics", "--resource-name", selectedTopic, "--operation", "read", "--pattern", "literal"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	if _, err := kafkaCtl.Execute("get", "acl", "--resource-name", selectedTopic, "-o", "yaml"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	entries, err := acl.FromYaml(kafkaCtl.GetStdOut())
+	if err != nil {
+		t.Fatalf("failed to read yaml: %v", err)
+	}
+	testutil.AssertIntEquals(t, 0, len(entries))
+
+	if _, err := kafkaCtl.Execute("get", "acl", "--resource-name", remainingTopic, "-o", "yaml"); err != nil {
+		t.Fatalf("failed to execute command: %v", err)
+	}
+
+	entries, err = acl.FromYaml(kafkaCtl.GetStdOut())
+	if err != nil {
+		t.Fatalf("failed to read yaml: %v", err)
+	}
+	testutil.AssertIntEquals(t, 1, len(entries))
+	testutil.AssertEquals(t, remainingTopic, entries[0].ResourceName)
+	testutil.AssertIntEquals(t, 1, len(entries[0].Acls))
+}

--- a/cmd/deletion/delete-acl.go
+++ b/cmd/deletion/delete-acl.go
@@ -26,6 +26,7 @@ func newDeleteACLCmd() *cobra.Command {
 
 	cmdDeleteACL.Flags().StringVarP(&flags.Operation, "operation", "o", "", "operation of acl")
 	cmdDeleteACL.Flags().StringVarP(&flags.PatternType, "pattern", "", "", "pattern type. one of (any, match, prefixed, literal)")
+	cmdDeleteACL.Flags().StringVarP(&flags.ResourceName, "resource-name", "r", "", "resource name of acl (e.g. topic name)")
 
 	cmdDeleteACL.Flags().StringVarP(&flags.Principal, "principal", "p", "", "principal of acl")
 	cmdDeleteACL.Flags().StringVarP(&flags.Host, "host", "", "", "host of acl")

--- a/internal/acl/acl-operation.go
+++ b/internal/acl/acl-operation.go
@@ -58,6 +58,7 @@ type DeleteACLFlags struct {
 	Cluster      bool
 	Allow        bool
 	Deny         bool
+	ResourceName string
 	Principal    string
 	Host         string
 	Operation    string
@@ -316,6 +317,10 @@ func (operation *Operation) DeleteACL(flags DeleteACLFlags) error {
 	} else {
 		filter.ResourceType = sarama.AclResourceCluster
 		filter.ResourcePatternTypeFilter = patternTypeFromString(flags.PatternType)
+	}
+
+	if flags.ResourceName != "" {
+		filter.ResourceName = &flags.ResourceName
 	}
 
 	if flags.Principal != "" {


### PR DESCRIPTION
# Description

Add `--resource-name/-r` to `delete acl` so deletion can be limited to one topic or group, matching the existing `get acl` filter.

Fixes #298

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Documentation

- [x] the change is mentioned in the `## [Unreleased]` section of `CHANGELOG.md`
- [x] a usage example was added to `README.adoc`
- [x] tests for the changes have been implemented